### PR TITLE
Add event photo management tab

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import Navigation from './components/Navigation';
 import EventsTab from './components/EventsTab';
+import EventPhotosTab from './components/EventPhotosTab';
 import WorkshopsTab from './components/WorkshopsTab';
 import TrainersTab from './components/TrainersTab';
 import ContractsTab from './components/ContractsTab';
@@ -50,9 +51,11 @@ function App() {
     switch (activeTab) {
       case 'events':
         return <EventsTab />;
+      case 'event-photos':
+        return <EventPhotosTab />;
       case 'workshops':
         return (
-          <WorkshopsTab 
+          <WorkshopsTab
             onNavigateWithFilter={handleNavigateWithFilter}
           />
         );

--- a/src/components/EventPhotosTab.tsx
+++ b/src/components/EventPhotosTab.tsx
@@ -1,0 +1,142 @@
+import React, { useState, useEffect } from 'react';
+import { Plus, Edit2, Trash2, Image as ImageIcon } from 'lucide-react';
+import { supabase } from '../lib/supabase';
+import EventPhotoForm from './forms/EventPhotoForm';
+import type { EventPhoto, Event } from '../types/database';
+
+const bucket = 'event-photos';
+
+const EventPhotosTab: React.FC = () => {
+  const [photos, setPhotos] = useState<EventPhoto[]>([]);
+  const [events, setEvents] = useState<Event[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [showForm, setShowForm] = useState(false);
+  const [editingPhoto, setEditingPhoto] = useState<EventPhoto | null>(null);
+
+  useEffect(() => {
+    fetchPhotos();
+    fetchEvents();
+  }, []);
+
+  const fetchPhotos = async () => {
+    try {
+      const { data, error } = await supabase
+        .from('event_photos')
+        .select('*')
+        .order('order', { ascending: true });
+      if (error) throw error;
+      setPhotos(data || []);
+    } catch (error) {
+      console.error('Erreur lors du chargement des photos:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const fetchEvents = async () => {
+    try {
+      const { data, error } = await supabase
+        .from('events')
+        .select('*');
+      if (error) throw error;
+      setEvents(data || []);
+    } catch (error) {
+      console.error('Erreur lors du chargement des événements:', error);
+    }
+  };
+
+  const getEventLabel = (eventId: string) => {
+    const event = events.find(e => e.id === eventId);
+    return event ? event.occasion : 'Événement inconnu';
+  };
+
+  const getPublicUrl = (path: string) => {
+    const { data } = supabase.storage.from(bucket).getPublicUrl(path);
+    return data.publicUrl;
+  };
+
+  const handleEdit = (photo: EventPhoto) => {
+    setEditingPhoto(photo);
+    setShowForm(true);
+  };
+
+  const handleDelete = async (photo: EventPhoto) => {
+    if (!confirm('Supprimer cette photo ?')) return;
+    try {
+      await supabase.storage.from(bucket).remove([photo.src]);
+      const { error } = await supabase
+        .from('event_photos')
+        .delete()
+        .eq('id', photo.id);
+      if (error) throw error;
+      fetchPhotos();
+    } catch (error) {
+      console.error('Erreur lors de la suppression:', error);
+    }
+  };
+
+  const handleCloseForm = () => {
+    setShowForm(false);
+    setEditingPhoto(null);
+  };
+
+  if (loading) {
+    return (
+      <div className="flex justify-center items-center h-64">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex justify-between items-center">
+        <h2 className="text-2xl font-bold text-gray-900">Gestion des Photos</h2>
+        <button
+          onClick={() => { setEditingPhoto(null); setShowForm(true); }}
+          className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg flex items-center space-x-2 transition-colors"
+        >
+          <Plus size={20} />
+          <span>Nouvelle Photo</span>
+        </button>
+      </div>
+
+      <div className="bg-white shadow-sm rounded-lg overflow-hidden">
+        <div className="grid gap-6 p-6">
+          {photos.length === 0 ? (
+            <div className="text-center py-12 text-gray-500">Aucune photo trouvée</div>
+          ) : (
+            photos.map(photo => (
+              <div key={photo.id} className="border border-gray-200 rounded-lg p-6 hover:shadow-md transition-shadow flex items-center space-x-4">
+                <img src={getPublicUrl(photo.src)} alt={photo.alt} className="w-24 h-24 object-cover rounded" />
+                <div className="flex-1">
+                  <h3 className="text-lg font-medium text-gray-900">{getEventLabel(photo.event_id)}</h3>
+                  <p className="text-sm text-gray-600">{photo.alt}</p>
+                </div>
+                <div className="flex space-x-2">
+                  <button onClick={() => handleEdit(photo)} className="p-2 text-blue-600 hover:bg-blue-50 rounded-lg transition-colors">
+                    <Edit2 size={18} />
+                  </button>
+                  <button onClick={() => handleDelete(photo)} className="p-2 text-red-600 hover:bg-red-50 rounded-lg transition-colors">
+                    <Trash2 size={18} />
+                  </button>
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+      </div>
+
+      {showForm && (
+        <EventPhotoForm
+          photo={editingPhoto}
+          onClose={handleCloseForm}
+          onSave={fetchPhotos}
+          events={events}
+        />
+      )}
+    </div>
+  );
+};
+
+export default EventPhotosTab;

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Calendar, Users, UserCheck, FileText, Settings, Contact as FileContract } from 'lucide-react';
+import { Calendar, Users, UserCheck, FileText, Settings, Contact as FileContract, Image } from 'lucide-react';
 
 interface NavigationProps {
   activeTab: string;
@@ -9,6 +9,7 @@ interface NavigationProps {
 const Navigation: React.FC<NavigationProps> = ({ activeTab, onTabChange }) => {
   const tabs = [
     { id: 'events', label: 'Événements', icon: Calendar },
+    { id: 'event-photos', label: 'Photos', icon: Image },
     { id: 'workshops', label: 'Ateliers', icon: Settings },
     { id: 'trainers', label: 'Formateurs', icon: Users },
     { id: 'contracts', label: 'Contrats', icon: FileContract },

--- a/src/components/forms/EventPhotoForm.tsx
+++ b/src/components/forms/EventPhotoForm.tsx
@@ -1,0 +1,185 @@
+import React, { useState, useEffect } from 'react';
+import { X, Save, Image as ImageIcon, FileText, Hash } from 'lucide-react';
+import { supabase } from '../../lib/supabase';
+import type { EventPhoto, Event } from '../../types/database';
+
+interface EventPhotoFormProps {
+  photo?: EventPhoto | null;
+  events: Event[];
+  onClose: () => void;
+  onSave: () => void;
+}
+
+const bucket = 'event-photos';
+
+const EventPhotoForm: React.FC<EventPhotoFormProps> = ({ photo, events, onClose, onSave }) => {
+  const [formData, setFormData] = useState({
+    event_id: '',
+    alt: '',
+    order: 0
+  });
+  const [file, setFile] = useState<File | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (photo) {
+      setFormData({
+        event_id: photo.event_id,
+        alt: photo.alt,
+        order: photo.order
+      });
+    }
+  }, [photo]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    setError('');
+
+    try {
+      let src = photo?.src || '';
+
+      if (!photo || file) {
+        if (!file) throw new Error('Image requise');
+        const extension = file.name.split('.').pop();
+        const filePath = `${formData.event_id}/${Date.now()}.${extension}`;
+        const { error: uploadError } = await supabase.storage.from(bucket).upload(filePath, file, { upsert: true });
+        if (uploadError) throw uploadError;
+        src = filePath;
+        if (photo && photo.src) {
+          await supabase.storage.from(bucket).remove([photo.src]);
+        }
+      }
+
+      const photoData = {
+        event_id: formData.event_id,
+        alt: formData.alt,
+        order: formData.order,
+        src
+      };
+
+      if (photo) {
+        const { error } = await supabase
+          .from('event_photos')
+          .update(photoData)
+          .eq('id', photo.id);
+        if (error) throw error;
+      } else {
+        const { error } = await supabase
+          .from('event_photos')
+          .insert([photoData]);
+        if (error) throw error;
+      }
+
+      onSave();
+      onClose();
+    } catch (err: any) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
+      <div className="bg-white rounded-lg max-w-lg w-full">
+        <div className="flex items-center justify-between p-6 border-b">
+          <h2 className="text-xl font-semibold text-gray-900">
+            {photo ? 'Modifier la photo' : 'Nouvelle photo'}
+          </h2>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-600 transition-colors">
+            <X size={24} />
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="p-6 space-y-6">
+          {error && (
+            <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-md">
+              {error}
+            </div>
+          )}
+
+          <div>
+            <label className="flex items-center space-x-2 text-sm font-medium text-gray-700 mb-2">
+              <ImageIcon size={16} />
+              <span>Image {photo ? '(laisser vide pour conserver)' : '*'} </span>
+            </label>
+            <input
+              type="file"
+              accept="image/*"
+              onChange={(e) => setFile(e.target.files ? e.target.files[0] : null)}
+              className="w-full"
+            />
+          </div>
+
+          <div>
+            <label className="flex items-center space-x-2 text-sm font-medium text-gray-700 mb-2">
+              <FileText size={16} />
+              <span>Texte alternatif *</span>
+            </label>
+            <input
+              type="text"
+              required
+              value={formData.alt}
+              onChange={(e) => setFormData(prev => ({ ...prev, alt: e.target.value }))}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            />
+          </div>
+
+          <div>
+            <label className="flex items-center space-x-2 text-sm font-medium text-gray-700 mb-2">
+              <Hash size={16} />
+              <span>Ordre *</span>
+            </label>
+            <input
+              type="number"
+              required
+              value={formData.order}
+              onChange={(e) => setFormData(prev => ({ ...prev, order: parseInt(e.target.value) }))}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            />
+          </div>
+
+          <div>
+            <label className="flex items-center space-x-2 text-sm font-medium text-gray-700 mb-2">
+              <FileText size={16} />
+              <span>Événement *</span>
+            </label>
+            <select
+              required
+              value={formData.event_id}
+              onChange={(e) => setFormData(prev => ({ ...prev, event_id: e.target.value }))}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            >
+              <option value="">Sélectionner un événement</option>
+              {events.map(ev => (
+                <option key={ev.id} value={ev.id}>{ev.occasion}</option>
+              ))}
+            </select>
+          </div>
+
+          <div className="flex justify-end space-x-3 pt-4 border-t">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-md transition-colors"
+            >
+              Annuler
+            </button>
+            <button
+              type="submit"
+              disabled={loading}
+              className="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-md transition-colors flex items-center space-x-2 disabled:opacity-50"
+            >
+              <Save size={16} />
+              <span>{loading ? 'Enregistrement...' : 'Enregistrer'}</span>
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default EventPhotoForm;

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -8,6 +8,15 @@ export interface Event {
   created_at?: string;
 }
 
+export interface EventPhoto {
+  id: string;
+  event_id: string;
+  src: string;
+  alt: string;
+  order: number;
+  created_at?: string;
+}
+
 export interface WorkshopPassword {
   id: string;
   date: string;


### PR DESCRIPTION
## Summary
- support managing event photos with new event-photos tab
- allow uploading photos to Supabase storage
- list photos and edit or delete them
- expose `EventPhoto` type

## Testing
- `npm run lint` *(fails: 26 errors, 9 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_685512dbab0883258a92c5ef6559c867