### PR TITLE
Add event photo filter and navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import { supabase } from './lib/supabase';
 function App() {
   const [activeTab, setActiveTab] = useState('events');
   const [selectedWorkshopDate, setSelectedWorkshopDate] = useState<string | null>(null);
+  const [selectedEventId, setSelectedEventId] = useState<string | null>(null);
   const [allWorkshopDates, setAllWorkshopDates] = useState<string[]>([]);
 
   useEffect(() => {
@@ -36,6 +37,7 @@ function App() {
     setActiveTab(tab);
     // Clear the filter when manually changing tabs
     setSelectedWorkshopDate(null);
+    setSelectedEventId(null);
   };
 
   const handleNavigateWithFilter = (tab: string, workshopDate?: string) => {
@@ -43,16 +45,30 @@ function App() {
     setSelectedWorkshopDate(workshopDate || null);
   };
 
+  const handleNavigateToPhotos = (eventId?: string) => {
+    setActiveTab('event-photos');
+    setSelectedEventId(eventId || null);
+  };
+
   const handleFilterChange = (date: string | null) => {
     setSelectedWorkshopDate(date);
+  };
+
+  const handleEventFilterChange = (eventId: string | null) => {
+    setSelectedEventId(eventId);
   };
 
   const renderActiveTab = () => {
     switch (activeTab) {
       case 'events':
-        return <EventsTab />;
+        return <EventsTab onManagePhotos={handleNavigateToPhotos} />;
       case 'event-photos':
-        return <EventPhotosTab />;
+        return (
+          <EventPhotosTab
+            initialFilterEventId={selectedEventId}
+            onFilterChange={handleEventFilterChange}
+          />
+        );
       case 'workshops':
         return (
           <WorkshopsTab

--- a/src/components/EventsTab.tsx
+++ b/src/components/EventsTab.tsx
@@ -1,12 +1,16 @@
 import React, { useState, useEffect } from 'react';
-import { Plus, Edit2, Trash2, MapPin, Clock } from 'lucide-react';
+import { Plus, Edit2, Trash2, MapPin, Clock, Image } from 'lucide-react';
 import { format } from 'date-fns';
 import { fr } from 'date-fns/locale';
 import { supabase } from '../lib/supabase';
 import EventForm from './forms/EventForm';
 import type { Event } from '../types/database';
 
-const EventsTab: React.FC = () => {
+interface EventsTabProps {
+  onManagePhotos: (eventId: string) => void;
+}
+
+const EventsTab: React.FC<EventsTabProps> = ({ onManagePhotos }) => {
   const [events, setEvents] = useState<Event[]>([]);
   const [loading, setLoading] = useState(true);
   const [showForm, setShowForm] = useState(false);
@@ -127,6 +131,13 @@ const EventsTab: React.FC = () => {
                       className="p-2 text-blue-600 hover:bg-blue-50 rounded-lg transition-colors"
                     >
                       <Edit2 size={18} />
+                    </button>
+                    <button
+                      onClick={() => onManagePhotos(event.id)}
+                      className="p-2 text-indigo-600 hover:bg-indigo-50 rounded-lg transition-colors"
+                      title="Modifier les photos"
+                    >
+                      <Image size={18} />
                     </button>
                     <button
                       onClick={() => handleDelete(event.id)}


### PR DESCRIPTION
## Summary
- filter event photos by associated event
- let Events tab open photo manager for a specific event
- keep selected event in state in App

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any and other existing issues)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685518bcbbcc8325abb11c2578b70de4