### PR TITLE
Add FAQ management tab

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import ContractsTab from './components/ContractsTab';
 import RegistrationsTab from './components/RegistrationsTab';
 import GuidelinesTab from './components/GuidelinesTab';
 import TestimonialsTab from './components/TestimonialsTab';
+import FaqsTab from './components/FaqsTab';
 import { supabase } from './lib/supabase';
 
 function App() {
@@ -92,6 +93,8 @@ function App() {
             onFilterChange={handleFilterChange}
           />
         );
+      case 'faqs':
+        return <FaqsTab />;
       case 'testimonials':
         return <TestimonialsTab />;
       default:

--- a/src/components/FaqsTab.tsx
+++ b/src/components/FaqsTab.tsx
@@ -1,0 +1,137 @@
+import React, { useState, useEffect } from 'react';
+import { Plus, Edit2, Trash2, FileText } from 'lucide-react';
+import { format } from 'date-fns';
+import { fr } from 'date-fns/locale';
+import { supabase } from '../lib/supabase';
+import FaqForm from './forms/FaqForm';
+import type { Faq } from '../types/database';
+
+const FaqsTab: React.FC = () => {
+  const [faqs, setFaqs] = useState<Faq[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [showForm, setShowForm] = useState(false);
+  const [editingFaq, setEditingFaq] = useState<Faq | null>(null);
+
+  useEffect(() => {
+    fetchFaqs();
+  }, []);
+
+  const fetchFaqs = async () => {
+    try {
+      const { data, error } = await supabase
+        .from('faqs')
+        .select('*')
+        .order('order', { ascending: true });
+      if (error) throw error;
+      setFaqs(data || []);
+    } catch (error) {
+      console.error('Erreur lors du chargement des FAQs:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleEdit = (faq: Faq) => {
+    setEditingFaq(faq);
+    setShowForm(true);
+  };
+
+  const handleDelete = async (faq: Faq) => {
+    if (!confirm('Supprimer cette FAQ ?')) return;
+    try {
+      const { error } = await supabase.from('faqs').delete().eq('id', faq.id);
+      if (error) throw error;
+      fetchFaqs();
+    } catch (error) {
+      console.error('Erreur lors de la suppression:', error);
+    }
+  };
+
+  const handleCloseForm = () => {
+    setShowForm(false);
+    setEditingFaq(null);
+  };
+
+  if (loading) {
+    return (
+      <div className="flex justify-center items-center h-64">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex justify-between items-center">
+        <h2 className="text-2xl font-bold text-gray-900">Gestion des FAQs</h2>
+        <button
+          onClick={() => {
+            setEditingFaq(null);
+            setShowForm(true);
+          }}
+          className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg flex items-center space-x-2 transition-colors"
+        >
+          <Plus size={20} />
+          <span>Nouvelle FAQ</span>
+        </button>
+      </div>
+
+      <div className="bg-white shadow-sm rounded-lg overflow-hidden">
+        <div className="grid gap-6 p-6">
+          {faqs.length === 0 ? (
+            <div className="text-center py-12 text-gray-500">Aucune FAQ trouvée</div>
+          ) : (
+            faqs.map((faq) => (
+              <div
+                key={faq.id}
+                className="border border-gray-200 rounded-lg p-6 hover:shadow-md transition-shadow"
+              >
+                <div className="flex justify-between items-start mb-4">
+                  <div className="flex items-center space-x-2">
+                    <FileText className="text-blue-600" size={20} />
+                    <h3 className="text-lg font-semibold text-gray-900">{faq.question}</h3>
+                  </div>
+                  <div className="flex space-x-2">
+                    <button
+                      onClick={() => handleEdit(faq)}
+                      className="p-2 text-blue-600 hover:bg-blue-50 rounded-lg transition-colors"
+                    >
+                      <Edit2 size={18} />
+                    </button>
+                    <button
+                      onClick={() => handleDelete(faq)}
+                      className="p-2 text-red-600 hover:bg-red-50 rounded-lg transition-colors"
+                    >
+                      <Trash2 size={18} />
+                    </button>
+                  </div>
+                </div>
+
+                <div className="bg-gray-50 rounded-md p-4">
+                  <h4 className="text-sm font-medium text-gray-900 mb-2">Réponse Markdown:</h4>
+                  <div className="max-h-96 overflow-y-auto">
+                    <pre className="text-sm text-gray-700 whitespace-pre-wrap break-words">
+                      {faq.answer}
+                    </pre>
+                  </div>
+                </div>
+
+                {faq.created_at && (
+                  <div className="mt-3 text-xs text-gray-500">
+                    Créé le {format(new Date(faq.created_at), 'dd MMMM yyyy à HH:mm', { locale: fr })}
+                  </div>
+                )}
+              </div>
+            ))
+          )}
+        </div>
+      </div>
+
+      {showForm && (
+        <FaqForm faq={editingFaq} onClose={handleCloseForm} onSave={fetchFaqs} />
+      )}
+    </div>
+  );
+};
+
+export default FaqsTab;

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Calendar, Users, UserCheck, FileText, Settings, Contact as FileContract, Image, MessageSquare } from 'lucide-react';
+import { Calendar, Users, UserCheck, FileText, Settings, Contact as FileContract, Image, MessageSquare, HelpCircle } from 'lucide-react';
 
 interface NavigationProps {
   activeTab: string;
@@ -15,6 +15,7 @@ const Navigation: React.FC<NavigationProps> = ({ activeTab, onTabChange }) => {
     { id: 'contracts', label: 'Contrats', icon: FileContract },
     { id: 'registrations', label: 'Inscriptions', icon: UserCheck },
     { id: 'guidelines', label: 'Directives', icon: FileText },
+    { id: 'faqs', label: 'FAQs', icon: HelpCircle },
     { id: 'testimonials', label: 'Témoignages', icon: MessageSquare },
   ];
 

--- a/src/components/forms/FaqForm.tsx
+++ b/src/components/forms/FaqForm.tsx
@@ -1,0 +1,190 @@
+import React, { useState, useEffect } from 'react';
+import { X, Save, FileText, Hash, Eye, EyeOff } from 'lucide-react';
+import { supabase } from '../../lib/supabase';
+import MarkdownRenderer from '../common/MarkdownRenderer';
+import type { Faq } from '../../types/database';
+
+interface FaqFormProps {
+  faq?: Faq | null;
+  onClose: () => void;
+  onSave: () => void;
+}
+
+const FaqForm: React.FC<FaqFormProps> = ({ faq, onClose, onSave }) => {
+  const [formData, setFormData] = useState({
+    question: '',
+    answer: '',
+    order: 0
+  });
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [showPreview, setShowPreview] = useState(false);
+
+  useEffect(() => {
+    if (faq) {
+      setFormData({
+        question: faq.question,
+        answer: faq.answer,
+        order: faq.order
+      });
+    }
+  }, [faq]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    setError('');
+
+    try {
+      const faqData = {
+        question: formData.question,
+        answer: formData.answer,
+        order: formData.order
+      };
+
+      if (faq) {
+        const { error } = await supabase
+          .from('faqs')
+          .update(faqData)
+          .eq('id', faq.id);
+        if (error) throw error;
+      } else {
+        const { error } = await supabase.from('faqs').insert([faqData]);
+        if (error) throw error;
+      }
+
+      onSave();
+      onClose();
+    } catch (err: any) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
+      <div className="bg-white rounded-lg max-w-xl w-full max-h-[90vh] overflow-y-auto">
+        <div className="flex items-center justify-between p-6 border-b">
+          <h2 className="text-xl font-semibold text-gray-900">
+            {faq ? 'Modifier la FAQ' : 'Nouvelle FAQ'}
+          </h2>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-600 transition-colors">
+            <X size={24} />
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="p-6 space-y-6">
+          {error && (
+            <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-md">
+              {error}
+            </div>
+          )}
+
+          <div>
+            <label className="flex items-center space-x-2 text-sm font-medium text-gray-700 mb-2">
+              <FileText size={16} />
+              <span>Question *</span>
+            </label>
+            <input
+              type="text"
+              required
+              value={formData.question}
+              onChange={(e) => setFormData(prev => ({ ...prev, question: e.target.value }))}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            />
+          </div>
+
+          <div>
+            <label className="flex items-center space-x-2 text-sm font-medium text-gray-700 mb-2">
+              <Hash size={16} />
+              <span>Ordre *</span>
+            </label>
+            <input
+              type="number"
+              required
+              value={formData.order}
+              onChange={(e) => setFormData(prev => ({ ...prev, order: parseInt(e.target.value) }))}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            />
+          </div>
+
+          <div className="flex items-center justify-between">
+            <label className="flex items-center space-x-2 text-sm font-medium text-gray-700">
+              <FileText size={16} />
+              <span>Réponse (Markdown) *</span>
+            </label>
+            <button
+              type="button"
+              onClick={() => setShowPreview(!showPreview)}
+              className={`flex items-center space-x-2 px-4 py-2 text-sm font-medium rounded-lg transition-colors ${
+                showPreview ? 'text-white bg-green-600 hover:bg-green-700' : 'text-gray-700 bg-gray-100 hover:bg-gray-200'
+              }`}
+            >
+              {showPreview ? <EyeOff size={16} /> : <Eye size={16} />}
+              <span>{showPreview ? 'Retour à l\'édition' : 'Prévisualiser'}</span>
+            </button>
+          </div>
+
+          {showPreview ? (
+            <div className="space-y-4">
+              <div className="bg-green-50 border border-green-200 rounded-lg p-4">
+                <div className="flex items-center space-x-2 mb-2">
+                  <Eye className="text-green-600" size={16} />
+                  <span className="font-medium text-green-900">Mode Prévisualisation</span>
+                </div>
+                <p className="text-sm text-green-700">Aperçu du rendu de la réponse.</p>
+              </div>
+
+              <div className="bg-white border border-gray-200 rounded-lg p-6 max-h-96 overflow-y-auto">
+                {formData.answer ? (
+                  <MarkdownRenderer content={formData.answer} style={{ fontSize: '14px' }} />
+                ) : (
+                  <div className="text-center py-12 text-gray-500">
+                    <FileText className="mx-auto mb-4" size={48} />
+                    <p className="text-lg font-medium mb-2">Aucun contenu à prévisualiser</p>
+                    <p className="text-sm">Retournez en mode édition pour saisir du contenu Markdown</p>
+                  </div>
+                )}
+              </div>
+            </div>
+          ) : (
+            <div className="space-y-4">
+              <textarea
+                required
+                rows={16}
+                value={formData.answer}
+                onChange={(e) => setFormData(prev => ({ ...prev, answer: e.target.value }))}
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent font-mono text-sm resize-none"
+                placeholder="Rédigez la réponse en Markdown..."
+              />
+              <p className="text-xs text-gray-500">
+                Utilisez la syntaxe Markdown pour formater le contenu (titres, listes, liens, etc.)
+              </p>
+            </div>
+          )}
+
+          <div className="flex justify-end space-x-3 pt-4 border-t">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-md transition-colors"
+            >
+              Annuler
+            </button>
+            <button
+              type="submit"
+              disabled={loading}
+              className="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-md transition-colors flex items-center space-x-2 disabled:opacity-50"
+            >
+              <Save size={16} />
+              <span>{loading ? 'Enregistrement...' : 'Enregistrer'}</span>
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default FaqForm;

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -124,3 +124,11 @@ export interface Testimonial {
   order: number;
   created_at?: string;
 }
+
+export interface Faq {
+  id: string;
+  question: string;
+  answer: string;
+  order: number;
+  created_at?: string;
+}


### PR DESCRIPTION
## Summary
- add `Faq` interface definition
- add FAQ form with markdown editing and preview
- create FAQ tab to list, edit and delete entries
- wire FAQ tab into navigation and app routing

## Testing
- `npm run lint` *(fails: several existing lint errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68551b39bbb8832592ef1227dc6e399e