### PR TITLE
Add initiatives management

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import ContractsTab from './components/ContractsTab';
 import RegistrationsTab from './components/RegistrationsTab';
 import GuidelinesTab from './components/GuidelinesTab';
 import TestimonialsTab from './components/TestimonialsTab';
+import InitiativesTab from './components/InitiativesTab';
 import { supabase } from './lib/supabase';
 
 function App() {
@@ -108,6 +109,8 @@ function App() {
             onFilterChange={handleFilterChange}
           />
         );
+      case 'initiatives':
+        return <InitiativesTab />;
       case 'testimonials':
         return <TestimonialsTab />;
       default:

--- a/src/components/InitiativesTab.tsx
+++ b/src/components/InitiativesTab.tsx
@@ -1,0 +1,146 @@
+import React, { useState, useEffect } from 'react';
+import { Plus, Edit2, Trash2 } from 'lucide-react';
+import { supabase } from '../lib/supabase';
+import InitiativeForm from './forms/InitiativeForm';
+import type { Initiative } from '../types/database';
+
+const bucket = 'initiatives';
+
+const InitiativesTab: React.FC = () => {
+  const [initiatives, setInitiatives] = useState<Initiative[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [showForm, setShowForm] = useState(false);
+  const [editingInitiative, setEditingInitiative] = useState<Initiative | null>(null);
+
+  useEffect(() => {
+    fetchInitiatives();
+  }, []);
+
+  const fetchInitiatives = async () => {
+    try {
+      const { data, error } = await supabase
+        .from('initiatives')
+        .select('*')
+        .order('created_at', { ascending: false });
+      if (error) throw error;
+      setInitiatives(data || []);
+    } catch (error) {
+      console.error('Erreur lors du chargement des initiatives:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleEdit = (initiative: Initiative) => {
+    setEditingInitiative(initiative);
+    setShowForm(true);
+  };
+
+  const handleDelete = async (initiative: Initiative) => {
+    if (!confirm('Supprimer cette initiative ?')) return;
+    try {
+      if (initiative.image_url) {
+        await supabase.storage.from(bucket).remove([initiative.image_url]);
+      }
+      if (initiative.logo_url) {
+        await supabase.storage.from(bucket).remove([initiative.logo_url]);
+      }
+      const { error } = await supabase.from('initiatives').delete().eq('id', initiative.id);
+      if (error) throw error;
+      fetchInitiatives();
+    } catch (error) {
+      console.error('Erreur lors de la suppression:', error);
+    }
+  };
+
+  const handleCloseForm = () => {
+    setShowForm(false);
+    setEditingInitiative(null);
+  };
+
+  const getPublicUrl = (path: string) => {
+    const { data } = supabase.storage.from(bucket).getPublicUrl(path);
+    return data.publicUrl;
+  };
+
+  if (loading) {
+    return (
+      <div className="flex justify-center items-center h-64">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex justify-between items-center">
+        <h2 className="text-2xl font-bold text-gray-900">Gestion des Initiatives</h2>
+        <button
+          onClick={() => {
+            setEditingInitiative(null);
+            setShowForm(true);
+          }}
+          className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg flex items-center space-x-2 transition-colors"
+        >
+          <Plus size={20} />
+          <span>Nouvelle Initiative</span>
+        </button>
+      </div>
+
+      <div className="bg-white shadow-sm rounded-lg overflow-hidden">
+        <div className="grid gap-6 p-6">
+          {initiatives.length === 0 ? (
+            <div className="text-center py-12 text-gray-500">Aucune initiative trouvée</div>
+          ) : (
+            initiatives.map((initiative) => (
+              <div
+                key={initiative.id}
+                className="border border-gray-200 rounded-lg p-6 flex justify-between items-start hover:shadow-md transition-shadow"
+              >
+                <div className="flex space-x-4">
+                  {initiative.logo_url && (
+                    <img src={getPublicUrl(initiative.logo_url)} alt={initiative.title} className="h-16 w-16 object-contain" />
+                  )}
+                  <div>
+                    <h3 className="text-lg font-semibold text-gray-900">{initiative.title}</h3>
+                    <p className="text-gray-700 mb-1">{initiative.description}</p>
+                    {initiative.locations.length > 0 && (
+                      <p className="text-sm text-gray-500">Lieux: {initiative.locations.join(', ')}</p>
+                    )}
+                    {initiative.specializations.length > 0 && (
+                      <p className="text-sm text-gray-500">Spécialisations: {initiative.specializations.join(', ')}</p>
+                    )}
+                  </div>
+                </div>
+                <div className="flex space-x-2">
+                  <button
+                    onClick={() => handleEdit(initiative)}
+                    className="p-2 text-blue-600 hover:bg-blue-50 rounded-lg transition-colors"
+                  >
+                    <Edit2 size={18} />
+                  </button>
+                  <button
+                    onClick={() => handleDelete(initiative)}
+                    className="p-2 text-red-600 hover:bg-red-50 rounded-lg transition-colors"
+                  >
+                    <Trash2 size={18} />
+                  </button>
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+      </div>
+
+      {showForm && (
+        <InitiativeForm
+          initiative={editingInitiative}
+          onClose={handleCloseForm}
+          onSave={fetchInitiatives}
+        />
+      )}
+    </div>
+  );
+};
+
+export default InitiativesTab;

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Calendar, Users, UserCheck, FileText, Settings, Contact as FileContract, Image, MessageSquare } from 'lucide-react';
+import { Calendar, Users, UserCheck, FileText, Settings, Contact as FileContract, Image, MessageSquare, Lightbulb } from 'lucide-react';
 
 interface NavigationProps {
   activeTab: string;
@@ -15,6 +15,7 @@ const Navigation: React.FC<NavigationProps> = ({ activeTab, onTabChange }) => {
     { id: 'contracts', label: 'Contrats', icon: FileContract },
     { id: 'registrations', label: 'Inscriptions', icon: UserCheck },
     { id: 'guidelines', label: 'Directives', icon: FileText },
+    { id: 'initiatives', label: 'Initiatives', icon: Lightbulb },
     { id: 'testimonials', label: 'Témoignages', icon: MessageSquare },
   ];
 

--- a/src/components/forms/InitiativeForm.tsx
+++ b/src/components/forms/InitiativeForm.tsx
@@ -1,0 +1,350 @@
+import React, { useState, useEffect } from 'react';
+import { X, Save, Plus, Trash2 } from 'lucide-react';
+import { supabase } from '../../lib/supabase';
+import type { Initiative, InitiativeSocialLink } from '../../types/database';
+
+interface InitiativeFormProps {
+  initiative?: Initiative | null;
+  onClose: () => void;
+  onSave: () => void;
+}
+
+const bucket = 'initiatives';
+
+const InitiativeForm: React.FC<InitiativeFormProps> = ({ initiative, onClose, onSave }) => {
+  const [formData, setFormData] = useState({
+    title: '',
+    description: '',
+    website_url: '',
+    start_date: '',
+    locations: [] as string[],
+    specializations: [] as string[],
+    social_links: [] as InitiativeSocialLink[],
+    image_url: '',
+    logo_url: ''
+  });
+
+  const [imageFile, setImageFile] = useState<File | null>(null);
+  const [logoFile, setLogoFile] = useState<File | null>(null);
+  const [imagePreview, setImagePreview] = useState<string | null>(null);
+  const [logoPreview, setLogoPreview] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (initiative) {
+      setFormData({
+        title: initiative.title,
+        description: initiative.description,
+        website_url: initiative.website_url,
+        start_date: initiative.start_date,
+        locations: initiative.locations || [],
+        specializations: initiative.specializations || [],
+        social_links: initiative.social_links || [],
+        image_url: initiative.image_url,
+        logo_url: initiative.logo_url
+      });
+      if (initiative.image_url) {
+        const { data } = supabase.storage.from(bucket).getPublicUrl(initiative.image_url);
+        setImagePreview(data.publicUrl);
+      }
+      if (initiative.logo_url) {
+        const { data } = supabase.storage.from(bucket).getPublicUrl(initiative.logo_url);
+        setLogoPreview(data.publicUrl);
+      }
+    }
+  }, [initiative]);
+
+  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0] || null;
+    setImageFile(file);
+    if (file) setImagePreview(URL.createObjectURL(file));
+  };
+
+  const handleLogoChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0] || null;
+    setLogoFile(file);
+    if (file) setLogoPreview(URL.createObjectURL(file));
+  };
+
+  const addLocation = () => {
+    setFormData(prev => ({ ...prev, locations: [...prev.locations, ''] }));
+  };
+
+  const updateLocation = (index: number, value: string) => {
+    const updated = formData.locations.map((loc, i) => (i === index ? value : loc));
+    setFormData(prev => ({ ...prev, locations: updated }));
+  };
+
+  const removeLocation = (index: number) => {
+    const updated = formData.locations.filter((_, i) => i !== index);
+    setFormData(prev => ({ ...prev, locations: updated }));
+  };
+
+  const addSpecialization = () => {
+    setFormData(prev => ({ ...prev, specializations: [...prev.specializations, ''] }));
+  };
+
+  const updateSpecialization = (index: number, value: string) => {
+    const updated = formData.specializations.map((sp, i) => (i === index ? value : sp));
+    setFormData(prev => ({ ...prev, specializations: updated }));
+  };
+
+  const removeSpecialization = (index: number) => {
+    const updated = formData.specializations.filter((_, i) => i !== index);
+    setFormData(prev => ({ ...prev, specializations: updated }));
+  };
+
+  const addSocialLink = () => {
+    setFormData(prev => ({
+      ...prev,
+      social_links: [...prev.social_links, { url: '', type: '', label: '' }]
+    }));
+  };
+
+  const updateSocialLink = (index: number, field: keyof InitiativeSocialLink, value: string) => {
+    const updated = formData.social_links.map((link, i) =>
+      i === index ? { ...link, [field]: value } : link
+    );
+    setFormData(prev => ({ ...prev, social_links: updated }));
+  };
+
+  const removeSocialLink = (index: number) => {
+    const updated = formData.social_links.filter((_, i) => i !== index);
+    setFormData(prev => ({ ...prev, social_links: updated }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    setError('');
+
+    try {
+      let imagePath = formData.image_url;
+      let logoPath = formData.logo_url;
+
+      if (imageFile) {
+        const ext = imageFile.name.split('.').pop();
+        const fileName = `image-${Date.now()}.${ext}`;
+        const { error: uploadError } = await supabase.storage.from(bucket).upload(fileName, imageFile, { upsert: true });
+        if (uploadError) throw uploadError;
+        imagePath = fileName;
+      }
+
+      if (logoFile) {
+        const ext = logoFile.name.split('.').pop();
+        const fileName = `logo-${Date.now()}.${ext}`;
+        const { error: uploadError } = await supabase.storage.from(bucket).upload(fileName, logoFile, { upsert: true });
+        if (uploadError) throw uploadError;
+        logoPath = fileName;
+      }
+
+      const data = {
+        title: formData.title,
+        description: formData.description,
+        website_url: formData.website_url,
+        start_date: formData.start_date,
+        locations: formData.locations.filter(l => l.trim()),
+        specializations: formData.specializations.filter(s => s.trim()),
+        social_links: formData.social_links,
+        image_url: imagePath,
+        logo_url: logoPath
+      };
+
+      if (initiative) {
+        const { error } = await supabase.from('initiatives').update(data).eq('id', initiative.id);
+        if (error) throw error;
+      } else {
+        const { error } = await supabase.from('initiatives').insert([data]);
+        if (error) throw error;
+      }
+
+      onSave();
+      onClose();
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Erreur inconnue';
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
+      <div className="bg-white rounded-lg w-full max-w-4xl max-h-[90vh] overflow-y-auto">
+        <div className="flex items-center justify-between p-6 border-b">
+          <h2 className="text-lg font-semibold text-gray-900">
+            {initiative ? 'Modifier l\'initiative' : 'Nouvelle initiative'}
+          </h2>
+          <button onClick={onClose} className="text-gray-500 hover:text-gray-700">
+            <X size={20} />
+          </button>
+        </div>
+        <form onSubmit={handleSubmit} className="p-6 space-y-6">
+          {error && <div className="text-red-500 text-sm">{error}</div>}
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700">Titre *</label>
+            <input
+              type="text"
+              required
+              value={formData.title}
+              onChange={e => setFormData(prev => ({ ...prev, title: e.target.value }))}
+              className="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:border-blue-500 focus:ring-blue-500 text-sm"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700">Description *</label>
+            <textarea
+              required
+              rows={4}
+              value={formData.description}
+              onChange={e => setFormData(prev => ({ ...prev, description: e.target.value }))}
+              className="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:border-blue-500 focus:ring-blue-500 text-sm"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700">Site web</label>
+            <input
+              type="url"
+              value={formData.website_url}
+              onChange={e => setFormData(prev => ({ ...prev, website_url: e.target.value }))}
+              className="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:border-blue-500 focus:ring-blue-500 text-sm"
+            />
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <div>
+              <label className="block text-sm font-medium text-gray-700">Image</label>
+              <input type="file" accept="image/*" onChange={handleImageChange} className="mt-1" />
+              {imagePreview && <img src={imagePreview} alt="Preview" className="mt-2 h-24" />}
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700">Logo</label>
+              <input type="file" accept="image/*" onChange={handleLogoChange} className="mt-1" />
+              {logoPreview && <img src={logoPreview} alt="Preview" className="mt-2 h-24" />}
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700">Date de début</label>
+            <input
+              type="date"
+              value={formData.start_date}
+              onChange={e => setFormData(prev => ({ ...prev, start_date: e.target.value }))}
+              className="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:border-blue-500 focus:ring-blue-500 text-sm"
+            />
+          </div>
+
+          <div>
+            <div className="flex items-center justify-between mb-2">
+              <label className="text-sm font-medium text-gray-700">Lieux</label>
+              <button type="button" onClick={addLocation} className="flex items-center space-x-1 text-sm text-green-600">
+                <Plus size={14} /> <span>Ajouter</span>
+              </button>
+            </div>
+            {formData.locations.length === 0 && <p className="text-sm text-gray-500">Aucun lieu ajouté</p>}
+            {formData.locations.map((loc, idx) => (
+              <div key={idx} className="flex items-center space-x-2 mb-2">
+                <input
+                  type="text"
+                  value={loc}
+                  onChange={e => updateLocation(idx, e.target.value)}
+                  className="flex-1 px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+                <button type="button" onClick={() => removeLocation(idx)} className="text-red-600 hover:text-red-800">
+                  <Trash2 size={16} />
+                </button>
+              </div>
+            ))}
+          </div>
+
+          <div>
+            <div className="flex items-center justify-between mb-2">
+              <label className="text-sm font-medium text-gray-700">Spécialisations</label>
+              <button type="button" onClick={addSpecialization} className="flex items-center space-x-1 text-sm text-green-600">
+                <Plus size={14} /> <span>Ajouter</span>
+              </button>
+            </div>
+            {formData.specializations.length === 0 && <p className="text-sm text-gray-500">Aucune spécialisation ajoutée</p>}
+            {formData.specializations.map((sp, idx) => (
+              <div key={idx} className="flex items-center space-x-2 mb-2">
+                <input
+                  type="text"
+                  value={sp}
+                  onChange={e => updateSpecialization(idx, e.target.value)}
+                  className="flex-1 px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+                <button type="button" onClick={() => removeSpecialization(idx)} className="text-red-600 hover:text-red-800">
+                  <Trash2 size={16} />
+                </button>
+              </div>
+            ))}
+          </div>
+
+          <div>
+            <div className="flex items-center justify-between mb-2">
+              <label className="text-sm font-medium text-gray-700">Liens sociaux</label>
+              <button type="button" onClick={addSocialLink} className="flex items-center space-x-1 text-sm text-green-600">
+                <Plus size={14} /> <span>Ajouter</span>
+              </button>
+            </div>
+            {formData.social_links.length === 0 && <p className="text-sm text-gray-500">Aucun lien ajouté</p>}
+            {formData.social_links.map((link, idx) => (
+              <div key={idx} className="grid grid-cols-1 md:grid-cols-3 gap-2 mb-2 items-center">
+                <input
+                  type="url"
+                  placeholder="URL"
+                  value={link.url}
+                  onChange={e => updateSocialLink(idx, 'url', e.target.value)}
+                  className="px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+                <input
+                  type="text"
+                  placeholder="Type"
+                  value={link.type}
+                  onChange={e => updateSocialLink(idx, 'type', e.target.value)}
+                  className="px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+                <div className="flex items-center space-x-2">
+                  <input
+                    type="text"
+                    placeholder="Label"
+                    value={link.label}
+                    onChange={e => updateSocialLink(idx, 'label', e.target.value)}
+                    className="flex-1 px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  />
+                  <button type="button" onClick={() => removeSocialLink(idx)} className="text-red-600 hover:text-red-800">
+                    <Trash2 size={16} />
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <div className="flex justify-end space-x-3 pt-4 border-t">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-md transition-colors"
+            >
+              Annuler
+            </button>
+            <button
+              type="submit"
+              disabled={loading}
+              className="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-md transition-colors flex items-center space-x-2 disabled:opacity-50"
+            >
+              <Save size={16} />
+              <span>{loading ? 'Enregistrement...' : 'Enregistrer'}</span>
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default InitiativeForm;

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -124,3 +124,23 @@ export interface Testimonial {
   order: number;
   created_at?: string;
 }
+
+export interface InitiativeSocialLink {
+  url: string;
+  type: string;
+  label: string;
+}
+
+export interface Initiative {
+  id: string;
+  title: string;
+  description: string;
+  image_url: string;
+  logo_url: string;
+  website_url: string;
+  locations: string[];
+  start_date: string;
+  specializations: string[];
+  social_links: InitiativeSocialLink[];
+  created_at?: string;
+}


### PR DESCRIPTION
## Summary
- add interfaces for Initiatives
- add Initiative form and tab
- integrate Initiatives in navigation and app routing

## Testing
- `npm run lint` *(fails: Unexpected any etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68551de1cb1c8325ac57601aa364925c