### PR TITLE
Add media highlight admin tab

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import GuidelinesTab from './components/GuidelinesTab';
 import TestimonialsTab from './components/TestimonialsTab';
 import InitiativesTab from './components/InitiativesTab';
 import FaqsTab from './components/FaqsTab';
+import MediaHighlightsTab from './components/MediaHighlightsTab';
 import { supabase } from './lib/supabase';
 
 function App() {
@@ -116,6 +117,8 @@ function App() {
         return <FaqsTab />;
       case 'testimonials':
         return <TestimonialsTab />;
+      case 'media-highlights':
+        return <MediaHighlightsTab />;
       default:
         return <EventsTab />;
     }

--- a/src/components/MediaHighlightsTab.tsx
+++ b/src/components/MediaHighlightsTab.tsx
@@ -1,0 +1,132 @@
+import React, { useState, useEffect } from 'react';
+import { Plus, Edit2, Trash2 } from 'lucide-react';
+import { format } from 'date-fns';
+import { fr } from 'date-fns/locale';
+import { supabase } from '../lib/supabase';
+import MediaHighlightForm from './forms/MediaHighlightForm';
+import type { MediaHighlight } from '../types/database';
+
+const MediaHighlightsTab: React.FC = () => {
+  const [highlights, setHighlights] = useState<MediaHighlight[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [showForm, setShowForm] = useState(false);
+  const [editingHighlight, setEditingHighlight] = useState<MediaHighlight | null>(null);
+
+  useEffect(() => {
+    fetchHighlights();
+  }, []);
+
+  const fetchHighlights = async () => {
+    try {
+      const { data, error } = await supabase
+        .from('media_highlights')
+        .select('*')
+        .order('date', { ascending: false });
+      if (error) throw error;
+      setHighlights(data || []);
+    } catch (err) {
+      console.error('Erreur lors du chargement des médias:', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleEdit = (h: MediaHighlight) => {
+    setEditingHighlight(h);
+    setShowForm(true);
+  };
+
+  const handleDelete = async (h: MediaHighlight) => {
+    if (!confirm('Supprimer cette mise en avant média ?')) return;
+    try {
+      const { error } = await supabase.from('media_highlights').delete().eq('id', h.id);
+      if (error) throw error;
+      fetchHighlights();
+    } catch (err) {
+      console.error('Erreur lors de la suppression:', err);
+    }
+  };
+
+  const handleCloseForm = () => {
+    setShowForm(false);
+    setEditingHighlight(null);
+  };
+
+  if (loading) {
+    return (
+      <div className="flex justify-center items-center h-64">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex justify-between items-center">
+        <h2 className="text-2xl font-bold text-gray-900">Gestion des Médias</h2>
+        <button
+          onClick={() => { setEditingHighlight(null); setShowForm(true); }}
+          className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg flex items-center space-x-2 transition-colors"
+        >
+          <Plus size={20} />
+          <span>Nouveau Média</span>
+        </button>
+      </div>
+
+      <div className="bg-white shadow-sm rounded-lg overflow-x-auto">
+        <table className="min-w-full divide-y divide-gray-200">
+          <thead className="bg-gray-50">
+            <tr>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Média</th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Titre</th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Date</th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Image</th>
+              <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
+            </tr>
+          </thead>
+          <tbody className="bg-white divide-y divide-gray-200">
+            {highlights.length === 0 ? (
+              <tr>
+                <td colSpan={5} className="px-6 py-4 text-center text-gray-500">Aucun média trouvé</td>
+              </tr>
+            ) : (
+              highlights.map((h) => (
+                <tr key={h.id} className="hover:bg-gray-50">
+                  <td className="px-6 py-4 whitespace-nowrap flex items-center space-x-2">
+                    <img src={h.media_logo} alt={h.media_name} className="h-8 w-8 object-contain" />
+                    <span className="text-sm font-medium text-gray-900">{h.media_name}</span>
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{h.title}</td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                    {format(new Date(h.date), 'dd/MM/yyyy', { locale: fr })}
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap">
+                    <img src={h.image_url} alt={h.title} className="h-12 w-12 object-cover rounded" />
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium space-x-2">
+                    <button onClick={() => handleEdit(h)} className="p-2 text-blue-600 hover:bg-blue-50 rounded-lg transition-colors">
+                      <Edit2 size={18} />
+                    </button>
+                    <button onClick={() => handleDelete(h)} className="p-2 text-red-600 hover:bg-red-50 rounded-lg transition-colors">
+                      <Trash2 size={18} />
+                    </button>
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {showForm && (
+        <MediaHighlightForm
+          highlight={editingHighlight}
+          onClose={handleCloseForm}
+          onSave={fetchHighlights}
+        />
+      )}
+    </div>
+  );
+};
+
+export default MediaHighlightsTab;

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Calendar, Users, UserCheck, FileText, Settings, Contact as FileContract, Image, MessageSquare, HelpCircle, Lightbulb } from 'lucide-react';
+import { Calendar, Users, UserCheck, FileText, Settings, Contact as FileContract, Image, MessageSquare, HelpCircle, Lightbulb, Newspaper } from 'lucide-react';
 
 interface NavigationProps {
   activeTab: string;
@@ -18,6 +18,7 @@ const Navigation: React.FC<NavigationProps> = ({ activeTab, onTabChange }) => {
     { id: 'initiatives', label: 'Initiatives', icon: Lightbulb },
     { id: 'faqs', label: 'FAQs', icon: HelpCircle },
     { id: 'testimonials', label: 'Témoignages', icon: MessageSquare },
+    { id: 'media-highlights', label: 'Médias', icon: Newspaper },
   ];
 
   return (

--- a/src/components/forms/MediaHighlightForm.tsx
+++ b/src/components/forms/MediaHighlightForm.tsx
@@ -1,0 +1,225 @@
+import React, { useState, useEffect } from 'react';
+import { X, Save, ExternalLink } from 'lucide-react';
+import { supabase } from '../../lib/supabase';
+import type { MediaHighlight } from '../../types/database';
+
+interface MediaHighlightFormProps {
+  highlight?: MediaHighlight | null;
+  onClose: () => void;
+  onSave: () => void;
+}
+
+const bucket = 'media-highlights';
+
+const MediaHighlightForm: React.FC<MediaHighlightFormProps> = ({ highlight, onClose, onSave }) => {
+  const [formData, setFormData] = useState({
+    title: '',
+    media_name: '',
+    date: '',
+    video_id: '',
+    url: '',
+    media_logo: '',
+    image_url: ''
+  });
+  const [logoFile, setLogoFile] = useState<File | null>(null);
+  const [imageFile, setImageFile] = useState<File | null>(null);
+  const [logoPreview, setLogoPreview] = useState<string | null>(null);
+  const [imagePreview, setImagePreview] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (highlight) {
+      setFormData({
+        title: highlight.title,
+        media_name: highlight.media_name,
+        date: highlight.date,
+        video_id: highlight.video_id || '',
+        url: highlight.url || '',
+        media_logo: highlight.media_logo,
+        image_url: highlight.image_url
+      });
+      if (highlight.media_logo) setLogoPreview(highlight.media_logo);
+      if (highlight.image_url) setImagePreview(highlight.image_url);
+    }
+  }, [highlight]);
+
+  const handleLogoChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0] || null;
+    setLogoFile(file);
+    if (file) setLogoPreview(URL.createObjectURL(file));
+  };
+
+  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0] || null;
+    setImageFile(file);
+    if (file) setImagePreview(URL.createObjectURL(file));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    setError('');
+
+    try {
+      let logoUrl = formData.media_logo;
+      let imageUrl = formData.image_url;
+
+      if (logoFile) {
+        const ext = logoFile.name.split('.').pop();
+        const fileName = `logo-${Date.now()}.${ext}`;
+        const { error: uploadError } = await supabase.storage.from(bucket).upload(fileName, logoFile, { upsert: true });
+        if (uploadError) throw uploadError;
+        const { data } = supabase.storage.from(bucket).getPublicUrl(fileName);
+        logoUrl = data.publicUrl;
+      }
+
+      if (imageFile) {
+        const ext = imageFile.name.split('.').pop();
+        const fileName = `image-${Date.now()}.${ext}`;
+        const { error: uploadError } = await supabase.storage.from(bucket).upload(fileName, imageFile, { upsert: true });
+        if (uploadError) throw uploadError;
+        const { data } = supabase.storage.from(bucket).getPublicUrl(fileName);
+        imageUrl = data.publicUrl;
+      }
+
+      const dataToSave = {
+        title: formData.title,
+        media_name: formData.media_name,
+        date: formData.date,
+        video_id: formData.video_id || null,
+        url: formData.url || null,
+        media_logo: logoUrl,
+        image_url: imageUrl
+      };
+
+      if (highlight) {
+        const { error } = await supabase
+          .from('media_highlights')
+          .update(dataToSave)
+          .eq('id', highlight.id);
+        if (error) throw error;
+      } else {
+        const { error } = await supabase.from('media_highlights').insert([dataToSave]);
+        if (error) throw error;
+      }
+
+      onSave();
+      onClose();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Erreur inconnue';
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
+      <div className="bg-white rounded-lg w-full max-w-lg max-h-[90vh] overflow-y-auto">
+        <div className="flex items-center justify-between p-6 border-b">
+          <h2 className="text-lg font-semibold text-gray-900">
+            {highlight ? 'Modifier le média' : 'Nouveau média'}
+          </h2>
+          <button onClick={onClose} className="text-gray-500 hover:text-gray-700">
+            <X size={20} />
+          </button>
+        </div>
+        <form onSubmit={handleSubmit} className="p-6 space-y-4">
+          {error && <div className="text-red-500 text-sm">{error}</div>}
+          <div>
+            <label className="block text-sm font-medium text-gray-700">Titre *</label>
+            <input
+              type="text"
+              required
+              value={formData.title}
+              onChange={(e) => setFormData(prev => ({ ...prev, title: e.target.value }))}
+              className="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:border-blue-500 focus:ring-blue-500 text-sm"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700">Nom du média *</label>
+            <input
+              type="text"
+              required
+              value={formData.media_name}
+              onChange={(e) => setFormData(prev => ({ ...prev, media_name: e.target.value }))}
+              className="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:border-blue-500 focus:ring-blue-500 text-sm"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700">Date *</label>
+            <input
+              type="date"
+              required
+              value={formData.date}
+              onChange={(e) => setFormData(prev => ({ ...prev, date: e.target.value }))}
+              className="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:border-blue-500 focus:ring-blue-500 text-sm"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700">ID vidéo (YouTube)</label>
+            <input
+              type="text"
+              value={formData.video_id}
+              onChange={(e) => setFormData(prev => ({ ...prev, video_id: e.target.value }))}
+              className="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:border-blue-500 focus:ring-blue-500 text-sm"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700">URL</label>
+            <div className="flex items-center space-x-2">
+              <input
+                type="url"
+                value={formData.url}
+                onChange={(e) => setFormData(prev => ({ ...prev, url: e.target.value }))}
+                className="mt-1 flex-1 border-gray-300 rounded-md shadow-sm focus:border-blue-500 focus:ring-blue-500 text-sm"
+              />
+              {formData.url && (
+                <a
+                  href={formData.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-blue-600 hover:underline flex items-center"
+                >
+                  <ExternalLink size={16} />
+                </a>
+              )}
+            </div>
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <div>
+              <label className="block text-sm font-medium text-gray-700">Logo</label>
+              <input type="file" accept="image/*" onChange={handleLogoChange} className="mt-1" />
+              {logoPreview && <img src={logoPreview} alt="Preview" className="mt-2 h-24" />}
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700">Image</label>
+              <input type="file" accept="image/*" onChange={handleImageChange} className="mt-1" />
+              {imagePreview && <img src={imagePreview} alt="Preview" className="mt-2 h-24" />}
+            </div>
+          </div>
+          <div className="flex justify-end space-x-3 pt-4 border-t">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-md transition-colors"
+            >
+              Annuler
+            </button>
+            <button
+              type="submit"
+              disabled={loading}
+              className="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-md transition-colors flex items-center space-x-2 disabled:opacity-50"
+            >
+              <Save size={16} />
+              <span>{loading ? 'Enregistrement...' : 'Enregistrer'}</span>
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default MediaHighlightForm;

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -152,3 +152,15 @@ export interface Faq {
   order: number;
   created_at?: string;
 }
+
+export interface MediaHighlight {
+  id: string;
+  title: string;
+  media_name: string;
+  media_logo: string;
+  date: string;
+  url: string | null;
+  video_id: string | null;
+  image_url: string;
+  created_at?: string;
+}

--- a/supabase/migrations/20250620090000_media_highlights.sql
+++ b/supabase/migrations/20250620090000_media_highlights.sql
@@ -1,0 +1,63 @@
+/*
+  # Add media_highlights table and storage bucket
+
+  1. New Table
+    - media_highlights (uuid, title, media_name, media_logo, date, url, video_id, image_url, created_at)
+  2. Storage
+    - Create `media-highlights` bucket
+    - Allow public file operations (insert, select, update, delete)
+  3. Security
+    - Enable RLS and add public policies for CRUD
+*/
+
+CREATE TABLE IF NOT EXISTS media_highlights (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  title text NOT NULL,
+  media_name text NOT NULL,
+  media_logo text NOT NULL,
+  date date NOT NULL,
+  url text,
+  video_id text,
+  image_url text NOT NULL,
+  created_at timestamptz DEFAULT now()
+);
+
+ALTER TABLE media_highlights ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Anyone can select media_highlights" ON media_highlights
+  FOR SELECT TO public
+  USING (true);
+
+CREATE POLICY "Anyone can insert media_highlights" ON media_highlights
+  FOR INSERT TO public
+  WITH CHECK (true);
+
+CREATE POLICY "Anyone can update media_highlights" ON media_highlights
+  FOR UPDATE TO public
+  USING (true)
+  WITH CHECK (true);
+
+CREATE POLICY "Anyone can delete media_highlights" ON media_highlights
+  FOR DELETE TO public
+  USING (true);
+
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('media-highlights', 'media-highlights', true)
+ON CONFLICT (id) DO NOTHING;
+
+CREATE POLICY "Anyone can upload media-highlights" ON storage.objects
+  FOR INSERT TO public
+  WITH CHECK (bucket_id = 'media-highlights');
+
+CREATE POLICY "Anyone can view media-highlights" ON storage.objects
+  FOR SELECT TO public
+  USING (bucket_id = 'media-highlights');
+
+CREATE POLICY "Anyone can update media-highlights" ON storage.objects
+  FOR UPDATE TO public
+  USING (bucket_id = 'media-highlights')
+  WITH CHECK (bucket_id = 'media-highlights');
+
+CREATE POLICY "Anyone can delete media-highlights" ON storage.objects
+  FOR DELETE TO public
+  USING (bucket_id = 'media-highlights');


### PR DESCRIPTION
## Summary
- manage media highlights in new admin tab
- support image uploads & preview via Supabase
- create database types and migrations

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_685521924d2c8325817a463808a68ff1