### PR TITLE
Add partners management

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import TestimonialsTab from './components/TestimonialsTab';
 import InitiativesTab from './components/InitiativesTab';
 import FaqsTab from './components/FaqsTab';
 import MediaHighlightsTab from './components/MediaHighlightsTab';
+import PartnersTab from './components/PartnersTab';
 import { supabase } from './lib/supabase';
 
 function App() {
@@ -117,6 +118,8 @@ function App() {
         return <FaqsTab />;
       case 'testimonials':
         return <TestimonialsTab />;
+      case 'partners':
+        return <PartnersTab />;
       case 'media-highlights':
         return <MediaHighlightsTab />;
       default:

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Calendar, Users, UserCheck, FileText, Settings, Contact as FileContract, Image, MessageSquare, HelpCircle, Lightbulb, Newspaper } from 'lucide-react';
+import { Calendar, Users, UserCheck, FileText, Settings, Contact as FileContract, Image, MessageSquare, HelpCircle, Lightbulb, Newspaper, Handshake } from 'lucide-react';
 
 interface NavigationProps {
   activeTab: string;
@@ -18,6 +18,7 @@ const Navigation: React.FC<NavigationProps> = ({ activeTab, onTabChange }) => {
     { id: 'initiatives', label: 'Initiatives', icon: Lightbulb },
     { id: 'faqs', label: 'FAQs', icon: HelpCircle },
     { id: 'testimonials', label: 'Témoignages', icon: MessageSquare },
+    { id: 'partners', label: 'Partenaires', icon: Handshake },
     { id: 'media-highlights', label: 'Médias', icon: Newspaper },
   ];
 

--- a/src/components/PartnersTab.tsx
+++ b/src/components/PartnersTab.tsx
@@ -1,0 +1,146 @@
+import React, { useState, useEffect } from 'react';
+import { Plus, Edit2, Trash2 } from 'lucide-react';
+import { format } from 'date-fns';
+import { fr } from 'date-fns/locale';
+import { supabase } from '../lib/supabase';
+import PartnerForm from './forms/PartnerForm';
+import type { Partner } from '../types/database';
+
+const bucket = 'partners';
+
+const PartnersTab: React.FC = () => {
+  const [partners, setPartners] = useState<Partner[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [showForm, setShowForm] = useState(false);
+  const [editingPartner, setEditingPartner] = useState<Partner | null>(null);
+
+  useEffect(() => {
+    fetchPartners();
+  }, []);
+
+  const fetchPartners = async () => {
+    try {
+      const { data, error } = await supabase
+        .from('partners')
+        .select('*')
+        .order('created_at', { ascending: false });
+      if (error) throw error;
+      setPartners(data || []);
+    } catch (error) {
+      console.error('Erreur lors du chargement des partenaires:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleEdit = (p: Partner) => {
+    setEditingPartner(p);
+    setShowForm(true);
+  };
+
+  const handleDelete = async (p: Partner) => {
+    if (!confirm('Supprimer ce partenaire ?')) return;
+    try {
+      if (p.logo_url) {
+        await supabase.storage.from(bucket).remove([p.logo_url]);
+      }
+      const { error } = await supabase.from('partners').delete().eq('id', p.id);
+      if (error) throw error;
+      fetchPartners();
+    } catch (error) {
+      console.error('Erreur lors de la suppression:', error);
+    }
+  };
+
+  const handleCloseForm = () => {
+    setShowForm(false);
+    setEditingPartner(null);
+  };
+
+  const getPublicUrl = (path: string) => {
+    const { data } = supabase.storage.from(bucket).getPublicUrl(path);
+    return data.publicUrl;
+  };
+
+  if (loading) {
+    return (
+      <div className="flex justify-center items-center h-64">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex justify-between items-center">
+        <h2 className="text-2xl font-bold text-gray-900">Gestion des Partenaires</h2>
+        <button
+          onClick={() => {
+            setEditingPartner(null);
+            setShowForm(true);
+          }}
+          className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg flex items-center space-x-2 transition-colors"
+        >
+          <Plus size={20} />
+          <span>Nouveau Partenaire</span>
+        </button>
+      </div>
+
+      <div className="bg-white shadow-sm rounded-lg overflow-x-auto">
+        <table className="min-w-full divide-y divide-gray-200">
+          <thead className="bg-gray-50">
+            <tr>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Nom</th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Logo</th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Site web</th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Depuis</th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Statut</th>
+              <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
+            </tr>
+          </thead>
+          <tbody className="bg-white divide-y divide-gray-200">
+            {partners.length === 0 ? (
+              <tr>
+                <td colSpan={6} className="px-6 py-4 text-center text-gray-500">Aucun partenaire trouvé</td>
+              </tr>
+            ) : (
+              partners.map((p) => (
+                <tr key={p.id} className="hover:bg-gray-50">
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{p.name}</td>
+                  <td className="px-6 py-4 whitespace-nowrap">
+                    {p.logo_url && (
+                      <img src={getPublicUrl(p.logo_url)} alt={p.name} className="h-8 w-8 object-contain" />
+                    )}
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap">
+                    <a href={p.website_url} target="_blank" rel="noopener" className="text-blue-600 hover:underline text-sm">
+                      {p.website_url}
+                    </a>
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                    {p.collaboration_date ? format(new Date(p.collaboration_date), 'dd/MM/yyyy', { locale: fr }) : ''}
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{p.collaboration_status || ''}</td>
+                  <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium space-x-2">
+                    <button onClick={() => handleEdit(p)} className="p-2 text-blue-600 hover:bg-blue-50 rounded-lg transition-colors">
+                      <Edit2 size={18} />
+                    </button>
+                    <button onClick={() => handleDelete(p)} className="p-2 text-red-600 hover:bg-red-50 rounded-lg transition-colors">
+                      <Trash2 size={18} />
+                    </button>
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {showForm && (
+        <PartnerForm partner={editingPartner} onClose={handleCloseForm} onSave={fetchPartners} />
+      )}
+    </div>
+  );
+};
+
+export default PartnersTab;

--- a/src/components/forms/PartnerForm.tsx
+++ b/src/components/forms/PartnerForm.tsx
@@ -1,0 +1,354 @@
+import React, { useState, useEffect } from 'react';
+import { X, Save, Plus, Trash2, ExternalLink } from 'lucide-react';
+import { supabase } from '../../lib/supabase';
+import type { Partner } from '../../types/database';
+
+interface PartnerFormProps {
+  partner?: Partner | null;
+  onClose: () => void;
+  onSave: () => void;
+}
+
+interface ResourceItem { url: string; description: string; }
+
+const bucket = 'partners';
+
+const PartnerForm: React.FC<PartnerFormProps> = ({ partner, onClose, onSave }) => {
+  const [formData, setFormData] = useState({
+    name: '',
+    logo_url: '',
+    website_url: '',
+    collaboration_date: '',
+    specializations: [] as string[],
+    locations: [] as string[],
+    resources: [] as ResourceItem[],
+    collaboration_status: ''
+  });
+  const [logoFile, setLogoFile] = useState<File | null>(null);
+  const [logoPreview, setLogoPreview] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [nameError, setNameError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (partner) {
+      setFormData({
+        name: partner.name,
+        logo_url: partner.logo_url,
+        website_url: partner.website_url,
+        collaboration_date: partner.collaboration_date || '',
+        specializations: partner.specializations || [],
+        locations: partner.locations || [],
+        resources: (partner.resources as ResourceItem[]) || [],
+        collaboration_status: partner.collaboration_status || ''
+      });
+      if (partner.logo_url) {
+        const { data } = supabase.storage.from(bucket).getPublicUrl(partner.logo_url);
+        setLogoPreview(data.publicUrl);
+      }
+    }
+  }, [partner]);
+
+  const checkNameUnique = async () => {
+    if (!formData.name.trim()) return;
+    const { data, error } = await supabase
+      .from('partners')
+      .select('id')
+      .eq('name', formData.name)
+      .maybeSingle();
+    if (error) return;
+    if (data && (!partner || data.id !== partner.id)) {
+      setNameError('Nom déjà utilisé');
+    } else {
+      setNameError(null);
+    }
+  };
+
+  const handleLogoChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0] || null;
+    setLogoFile(file);
+    if (file) setLogoPreview(URL.createObjectURL(file));
+  };
+
+  const addSpecialization = () =>
+    setFormData(prev => ({ ...prev, specializations: [...prev.specializations, ''] }));
+  const updateSpecialization = (i: number, val: string) => {
+    const updated = formData.specializations.map((sp, idx) => (idx === i ? val : sp));
+    setFormData(prev => ({ ...prev, specializations: updated }));
+  };
+  const removeSpecialization = (i: number) => {
+    const updated = formData.specializations.filter((_, idx) => idx !== i);
+    setFormData(prev => ({ ...prev, specializations: updated }));
+  };
+
+  const addLocation = () =>
+    setFormData(prev => ({ ...prev, locations: [...prev.locations, ''] }));
+  const updateLocation = (i: number, val: string) => {
+    const updated = formData.locations.map((loc, idx) => (idx === i ? val : loc));
+    setFormData(prev => ({ ...prev, locations: updated }));
+  };
+  const removeLocation = (i: number) => {
+    const updated = formData.locations.filter((_, idx) => idx !== i);
+    setFormData(prev => ({ ...prev, locations: updated }));
+  };
+
+  const addResource = () =>
+    setFormData(prev => ({ ...prev, resources: [...prev.resources, { url: '', description: '' }] }));
+  const updateResource = (i: number, field: keyof ResourceItem, val: string) => {
+    const updated = formData.resources.map((r, idx) => (idx === i ? { ...r, [field]: val } : r));
+    setFormData(prev => ({ ...prev, resources: updated }));
+  };
+  const removeResource = (i: number) => {
+    const updated = formData.resources.filter((_, idx) => idx !== i);
+    setFormData(prev => ({ ...prev, resources: updated }));
+  };
+
+  const openWebsite = () => {
+    if (formData.website_url) window.open(formData.website_url, '_blank');
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    setError('');
+
+    await checkNameUnique();
+    if (nameError) {
+      setLoading(false);
+      return;
+    }
+
+    try {
+      let logoPath = formData.logo_url;
+
+      if (logoFile) {
+        const ext = logoFile.name.split('.').pop();
+        const fileName = `logo-${Date.now()}.${ext}`;
+        const { error: uploadError } = await supabase.storage
+          .from(bucket)
+          .upload(fileName, logoFile, { upsert: true });
+        if (uploadError) throw uploadError;
+        logoPath = fileName;
+      }
+
+      const data = {
+        name: formData.name,
+        logo_url: logoPath,
+        website_url: formData.website_url,
+        collaboration_date: formData.collaboration_date || null,
+        specializations: formData.specializations.filter(s => s.trim()),
+        locations: formData.locations.filter(l => l.trim()),
+        resources: formData.resources.length > 0 ? formData.resources : null,
+        collaboration_status: formData.collaboration_status.trim() || null
+      };
+
+      if (partner) {
+        const { error } = await supabase.from('partners').update(data).eq('id', partner.id);
+        if (error) throw error;
+      } else {
+        const { error } = await supabase.from('partners').insert([data]);
+        if (error) throw error;
+      }
+
+      onSave();
+      onClose();
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Erreur inconnue';
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
+      <div className="bg-white rounded-lg w-full max-w-4xl max-h-[90vh] overflow-y-auto">
+        <div className="flex items-center justify-between p-6 border-b">
+          <h2 className="text-lg font-semibold text-gray-900">
+            {partner ? 'Modifier le partenaire' : 'Nouveau partenaire'}
+          </h2>
+          <button onClick={onClose} className="text-gray-500 hover:text-gray-700">
+            <X size={20} />
+          </button>
+        </div>
+        <form onSubmit={handleSubmit} className="p-6 space-y-6">
+          {error && <div className="text-red-500 text-sm">{error}</div>}
+          {partner && (
+            <div>
+              <label className="block text-sm font-medium text-gray-700">ID</label>
+              <input
+                type="text"
+                readOnly
+                value={partner.id}
+                className="mt-1 block w-full border-gray-300 rounded-md text-sm"
+              />
+            </div>
+          )}
+          <div>
+            <label className="block text-sm font-medium text-gray-700">Nom *</label>
+            <input
+              type="text"
+              required
+              value={formData.name}
+              onChange={e => setFormData(prev => ({ ...prev, name: e.target.value }))}
+              onBlur={checkNameUnique}
+              className="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:border-blue-500 focus:ring-blue-500 text-sm"
+            />
+            {nameError && <p className="text-sm text-red-500 mt-1">{nameError}</p>}
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700">Logo *</label>
+            <input type="file" accept="image/*" onChange={handleLogoChange} className="mt-1" />
+            {logoPreview && <img src={logoPreview} alt="Preview" className="mt-2 h-24" />}
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700">Site web *</label>
+            <div className="flex space-x-2">
+              <input
+                type="url"
+                required
+                value={formData.website_url}
+                onChange={e => setFormData(prev => ({ ...prev, website_url: e.target.value }))}
+                className="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:border-blue-500 focus:ring-blue-500 text-sm"
+              />
+              <button
+                type="button"
+                onClick={openWebsite}
+                className="px-3 py-2 bg-gray-100 rounded-md text-gray-700 hover:bg-gray-200"
+              >
+                <ExternalLink size={16} />
+              </button>
+            </div>
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700">Date de collaboration</label>
+            <input
+              type="date"
+              value={formData.collaboration_date}
+              onChange={e => setFormData(prev => ({ ...prev, collaboration_date: e.target.value }))}
+              className="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:border-blue-500 focus:ring-blue-500 text-sm"
+            />
+          </div>
+          <div>
+            <div className="flex items-center justify-between mb-2">
+              <label className="text-sm font-medium text-gray-700">Spécialisations</label>
+              <button type="button" onClick={addSpecialization} className="flex items-center space-x-1 text-sm text-green-600">
+                <Plus size={14} /> <span>Ajouter</span>
+              </button>
+            </div>
+            {formData.specializations.length === 0 && <p className="text-sm text-gray-500">Aucune spécialisation ajoutée</p>}
+            {formData.specializations.map((sp, idx) => (
+              <div key={idx} className="flex items-center space-x-2 mb-2">
+                <input
+                  type="text"
+                  value={sp}
+                  onChange={e => updateSpecialization(idx, e.target.value)}
+                  className="flex-1 px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+                <button type="button" onClick={() => removeSpecialization(idx)} className="text-red-600 hover:text-red-800">
+                  <Trash2 size={16} />
+                </button>
+              </div>
+            ))}
+          </div>
+          <div>
+            <div className="flex items-center justify-between mb-2">
+              <label className="text-sm font-medium text-gray-700">Lieux</label>
+              <button type="button" onClick={addLocation} className="flex items-center space-x-1 text-sm text-green-600">
+                <Plus size={14} /> <span>Ajouter</span>
+              </button>
+            </div>
+            {formData.locations.length === 0 && <p className="text-sm text-gray-500">Aucun lieu ajouté</p>}
+            {formData.locations.map((loc, idx) => (
+              <div key={idx} className="flex items-center space-x-2 mb-2">
+                <input
+                  type="text"
+                  value={loc}
+                  onChange={e => updateLocation(idx, e.target.value)}
+                  className="flex-1 px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+                <button type="button" onClick={() => removeLocation(idx)} className="text-red-600 hover:text-red-800">
+                  <Trash2 size={16} />
+                </button>
+              </div>
+            ))}
+          </div>
+          <div>
+            <div className="flex items-center justify-between mb-2">
+              <label className="text-sm font-medium text-gray-700">Ressources</label>
+              <button type="button" onClick={addResource} className="flex items-center space-x-1 text-sm text-green-600">
+                <Plus size={14} /> <span>Ajouter</span>
+              </button>
+            </div>
+            {formData.resources.length === 0 && <p className="text-sm text-gray-500">Aucune ressource ajoutée</p>}
+            {formData.resources.map((res, idx) => (
+              <div key={idx} className="grid grid-cols-1 md:grid-cols-3 gap-2 mb-2 items-center">
+                <input
+                  type="url"
+                  placeholder="URL"
+                  value={res.url}
+                  onChange={e => updateResource(idx, 'url', e.target.value)}
+                  className="px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+                <div className="flex items-center md:col-span-2 space-x-2">
+                  <input
+                    type="text"
+                    placeholder="Description"
+                    value={res.description}
+                    onChange={e => updateResource(idx, 'description', e.target.value)}
+                    className="flex-1 px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  />
+                  <button type="button" onClick={() => removeResource(idx)} className="text-red-600 hover:text-red-800">
+                    <Trash2 size={16} />
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700">Statut de collaboration</label>
+            <input
+              type="text"
+              value={formData.collaboration_status}
+              onChange={e => setFormData(prev => ({ ...prev, collaboration_status: e.target.value }))}
+              placeholder="Mois Année"
+              pattern="^[A-Za-zÀ-ÿ]+ [0-9]{4}$"
+              className="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:border-blue-500 focus:ring-blue-500 text-sm"
+            />
+            <p className="text-xs text-gray-500 mt-1">Exemple : Juin 2024</p>
+          </div>
+          {partner && (
+            <div>
+              <label className="block text-sm font-medium text-gray-700">Créé le</label>
+              <input
+                type="text"
+                readOnly
+                value={new Date(partner.created_at ?? '').toLocaleString()}
+                className="mt-1 block w-full border-gray-300 rounded-md text-sm"
+              />
+            </div>
+          )}
+          <div className="flex justify-end space-x-3 pt-4 border-t">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-md transition-colors"
+            >
+              Annuler
+            </button>
+            <button
+              type="submit"
+              disabled={loading}
+              className="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-md transition-colors flex items-center space-x-2 disabled:opacity-50"
+            >
+              <Save size={16} />
+              <span>{loading ? 'Enregistrement...' : 'Enregistrer'}</span>
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default PartnerForm;

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -164,3 +164,16 @@ export interface MediaHighlight {
   image_url: string;
   created_at?: string;
 }
+
+export interface Partner {
+  id: string;
+  name: string;
+  logo_url: string;
+  website_url: string;
+  created_at?: string;
+  collaboration_date: string | null;
+  specializations: string[] | null;
+  resources: { url: string; description: string }[] | null;
+  locations: string[] | null;
+  collaboration_status: string | null;
+}

--- a/supabase/migrations/20250620110000_partners.sql
+++ b/supabase/migrations/20250620110000_partners.sql
@@ -1,0 +1,78 @@
+/*
+  # Add partners table and storage bucket
+
+  1. Function
+    - Create validate_resources() to validate JSON resources
+  2. Table Definition
+    - Create partners table with constraints
+    - Trigger to run validation
+  3. Storage
+    - Create partners bucket with public policies
+*/
+
+-- Function to validate resources JSON structure
+CREATE OR REPLACE FUNCTION validate_resources()
+RETURNS TRIGGER AS $$
+DECLARE
+  item jsonb;
+BEGIN
+  IF NEW.resources IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  FOR item IN SELECT * FROM jsonb_array_elements(NEW.resources)
+  LOOP
+    IF NOT (item ? 'url') OR NOT (item ? 'description') THEN
+      RAISE EXCEPTION 'Chaque ressource doit contenir les champs url et description';
+    END IF;
+    IF NOT (item->>'url' ~* '^https?://') THEN
+      RAISE EXCEPTION 'URL invalide dans resources: %', item->>'url';
+    END IF;
+  END LOOP;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Partners table
+CREATE TABLE IF NOT EXISTS public.partners (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  name text NOT NULL UNIQUE,
+  logo_url text NOT NULL,
+  website_url text NOT NULL,
+  created_at timestamp with time zone DEFAULT now(),
+  collaboration_date date NULL,
+  specializations text[] NULL,
+  resources jsonb NULL,
+  locations text[] NULL,
+  collaboration_status text NULL,
+  CONSTRAINT collaboration_status_check CHECK (
+    collaboration_status IS NULL OR
+    collaboration_status ~ '^[A-Za-zÀ-ÿ]+ [0-9]{4}$'
+  )
+);
+
+CREATE TRIGGER validate_resources_trigger
+BEFORE INSERT OR UPDATE ON public.partners
+FOR EACH ROW EXECUTE FUNCTION validate_resources();
+
+-- Storage bucket for partner logos
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('partners', 'partners', true)
+ON CONFLICT (id) DO NOTHING;
+
+CREATE POLICY "Anyone can upload partners" ON storage.objects
+  FOR INSERT TO public
+  WITH CHECK (bucket_id = 'partners');
+
+CREATE POLICY "Anyone can view partners" ON storage.objects
+  FOR SELECT TO public
+  USING (bucket_id = 'partners');
+
+CREATE POLICY "Anyone can update partners" ON storage.objects
+  FOR UPDATE TO public
+  USING (bucket_id = 'partners')
+  WITH CHECK (bucket_id = 'partners');
+
+CREATE POLICY "Anyone can delete partners" ON storage.objects
+  FOR DELETE TO public
+  USING (bucket_id = 'partners');


### PR DESCRIPTION
## Summary
- add Partner interface to database types
- implement PartnerForm and PartnersTab to manage partners
- wire partners in Navigation and App
- create partners table and storage bucket migration

## Testing
- `npm run lint` *(fails: 37 problems, 27 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68552656971c8325852ad0f09cbe9d64