### PR TITLE
Use card layout for trainer, press and media tabs

### DIFF
--- a/src/components/MediaHighlightsTab.tsx
+++ b/src/components/MediaHighlightsTab.tsx
@@ -73,49 +73,39 @@ const MediaHighlightsTab: React.FC = () => {
         </button>
       </div>
 
-      <div className="bg-white shadow-sm rounded-lg overflow-x-auto">
-        <table className="min-w-full divide-y divide-gray-200">
-          <thead className="bg-gray-50">
-            <tr>
-              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Média</th>
-              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Titre</th>
-              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Date</th>
-              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Image</th>
-              <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
-            </tr>
-          </thead>
-          <tbody className="bg-white divide-y divide-gray-200">
-            {highlights.length === 0 ? (
-              <tr>
-                <td colSpan={5} className="px-6 py-4 text-center text-gray-500">Aucun média trouvé</td>
-              </tr>
-            ) : (
-              highlights.map((h) => (
-                <tr key={h.id} className="hover:bg-gray-50">
-                  <td className="px-6 py-4 whitespace-nowrap flex items-center space-x-2">
-                    <img src={h.media_logo} alt={h.media_name} className="h-8 w-8 object-contain" />
-                    <span className="text-sm font-medium text-gray-900">{h.media_name}</span>
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{h.title}</td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                    {format(new Date(h.date), 'dd/MM/yyyy', { locale: fr })}
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap">
-                    <img src={h.image_url} alt={h.title} className="h-12 w-12 object-cover rounded" />
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium space-x-2">
+      <div className="bg-white shadow-sm rounded-lg overflow-hidden">
+        <div className="grid gap-6 p-6">
+          {highlights.length === 0 ? (
+            <div className="text-center py-12 text-gray-500">Aucun média trouvé</div>
+          ) : (
+            highlights.map((h) => (
+              <div key={h.id} className="border border-gray-200 rounded-lg p-6 hover:shadow-md transition-shadow">
+                <div className="flex justify-between items-start mb-4">
+                  <div className="flex-1">
+                    <div className="flex items-center space-x-3 mb-2">
+                      <img src={h.media_logo} alt={h.media_name} className="h-8 w-8 object-contain" />
+                      <h3 className="text-lg font-semibold text-gray-900">{h.title}</h3>
+                    </div>
+                    <p className="text-sm text-gray-600">
+                      {h.media_name} - {format(new Date(h.date), 'dd/MM/yyyy', { locale: fr })}
+                    </p>
+                    <div className="mt-2">
+                      <img src={h.image_url} alt={h.title} className="h-32 w-full object-cover rounded" />
+                    </div>
+                  </div>
+                  <div className="flex space-x-2 ml-4">
                     <button onClick={() => handleEdit(h)} className="p-2 text-blue-600 hover:bg-blue-50 rounded-lg transition-colors">
                       <Edit2 size={18} />
                     </button>
                     <button onClick={() => handleDelete(h)} className="p-2 text-red-600 hover:bg-red-50 rounded-lg transition-colors">
                       <Trash2 size={18} />
                     </button>
-                  </td>
-                </tr>
-              ))
-            )}
-          </tbody>
-        </table>
+                  </div>
+                </div>
+              </div>
+            ))
+          )}
+        </div>
       </div>
 
       {showForm && (

--- a/src/components/PressArticlesTab.tsx
+++ b/src/components/PressArticlesTab.tsx
@@ -82,62 +82,50 @@ const PressArticlesTab: React.FC = () => {
         </button>
       </div>
 
-      <div className="bg-white shadow-sm rounded-lg overflow-x-auto">
-        <table className="min-w-full divide-y divide-gray-200">
-          <thead className="bg-gray-50">
-            <tr>
-              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Publication</th>
-              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Logo</th>
-              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Titre</th>
-              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">URL</th>
-              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Date</th>
-              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Mis en avant</th>
-              <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
-            </tr>
-          </thead>
-          <tbody className="bg-white divide-y divide-gray-200">
-            {articles.length === 0 ? (
-              <tr>
-                <td colSpan={7} className="px-6 py-4 text-center text-gray-500">Aucun article trouvé</td>
-              </tr>
-            ) : (
-              articles.map((a) => (
-                <tr key={a.id} className="hover:bg-gray-50">
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{a.publication}</td>
-                  <td className="px-6 py-4 whitespace-nowrap">
-                    {a.logo_url && (
-                      <img src={getPublicUrl(a.logo_url)} alt={a.publication} className="h-8 w-8 object-contain" />
-                    )}
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{a.title}</td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm">
-                    <a href={a.url} target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:underline">
-                      {a.url}
-                    </a>
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                    {format(new Date(a.date), 'dd/MM/yyyy', { locale: fr })}
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap">
-                    {a.featured ? (
-                      <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-green-100 text-green-800">Oui</span>
-                    ) : (
-                      <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-gray-100 text-gray-600">Non</span>
-                    )}
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium space-x-2">
+      <div className="bg-white shadow-sm rounded-lg overflow-hidden">
+        <div className="grid gap-6 p-6">
+          {articles.length === 0 ? (
+            <div className="text-center py-12 text-gray-500">Aucun article trouvé</div>
+          ) : (
+            articles.map((a) => (
+              <div key={a.id} className="border border-gray-200 rounded-lg p-6 hover:shadow-md transition-shadow">
+                <div className="flex justify-between items-start mb-4">
+                  <div className="flex-1">
+                    <div className="flex items-center space-x-3 mb-2">
+                      {a.logo_url && (
+                        <img src={getPublicUrl(a.logo_url)} alt={a.publication} className="h-8 w-8 object-contain" />
+                      )}
+                      <h3 className="text-lg font-semibold text-gray-900">{a.title}</h3>
+                    </div>
+                    <p className="text-sm text-gray-600">
+                      {a.publication} - {format(new Date(a.date), 'dd/MM/yyyy', { locale: fr })}
+                    </p>
+                    <p className="mt-2 text-sm">
+                      <a href={a.url} target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:underline">
+                        {a.url}
+                      </a>
+                    </p>
+                    <div className="mt-2">
+                      {a.featured ? (
+                        <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-green-100 text-green-800">Mis en avant</span>
+                      ) : (
+                        <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-gray-100 text-gray-600">Standard</span>
+                      )}
+                    </div>
+                  </div>
+                  <div className="flex space-x-2 ml-4">
                     <button onClick={() => handleEdit(a)} className="p-2 text-blue-600 hover:bg-blue-50 rounded-lg transition-colors">
                       <Edit2 size={18} />
                     </button>
                     <button onClick={() => handleDelete(a)} className="p-2 text-red-600 hover:bg-red-50 rounded-lg transition-colors">
                       <Trash2 size={18} />
                     </button>
-                  </td>
-                </tr>
-              ))
-            )}
-          </tbody>
-        </table>
+                  </div>
+                </div>
+              </div>
+            ))
+          )}
+        </div>
       </div>
 
       {showForm && (

--- a/src/components/TrainersTab.tsx
+++ b/src/components/TrainersTab.tsx
@@ -402,99 +402,40 @@ const TrainersTab: React.FC<TrainersTabProps> = ({ initialFilterDate, allWorksho
       </div>
 
       <div className="bg-white shadow-sm rounded-lg overflow-hidden">
-        <div className="overflow-x-auto">
-          <table className="min-w-full divide-y divide-gray-200">
-            <thead className="bg-gray-50">
-              <tr>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  Date Atelier
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  Code Formateur
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  Statut
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  Contrat Affecté
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  Contrat Accepté
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  Code Envoyé
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  Abandonné
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  Date de Création
-                </th>
-                <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  Actions
-                </th>
-              </tr>
-            </thead>
-            <tbody className="bg-white divide-y divide-gray-200">
-              {trainers.length === 0 ? (
-                <tr>
-                  <td colSpan={9} className="px-6 py-12 text-center text-gray-500">
-                    {filterDate ? 'Aucun formateur trouvé pour cet atelier' : 'Aucun formateur trouvé'}
-                  </td>
-                </tr>
-              ) : (
-                trainers.map((trainer) => (
-                  <tr key={trainer.id} className={`hover:bg-gray-50 ${trainer.is_abandoned ? 'bg-red-50' : ''}`}>
-                    <td className="px-6 py-4 whitespace-nowrap">
-                      <div className="flex items-center">
-                        <Users className="text-blue-600 mr-2" size={16} />
-                        <span className="text-sm font-medium text-gray-900">
-                          {format(new Date(trainer.workshop_date), 'dd MMMM yyyy', { locale: fr })}
-                        </span>
-                      </div>
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap">
-                      <code className={`px-2 py-1 rounded text-sm font-mono ${
-                        trainer.is_abandoned 
-                          ? 'bg-red-100 text-red-800 line-through' 
-                          : 'bg-gray-100'
-                      }`}>
-                        {trainer.trainer_code}
-                      </code>
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap">
-                      <div className="flex items-center">
-                        {trainer.is_abandoned ? (
-                          <>
-                            <UserX className="text-red-500 mr-1" size={16} />
-                            <span className="text-sm text-red-800 bg-red-100 px-2 py-1 rounded-full">
-                              Abandonné
-                            </span>
-                          </>
-                        ) : trainer.is_claimed ? (
-                          <>
-                            <CheckCircle className="text-green-500 mr-1" size={16} />
-                            <span className="text-sm text-green-800 bg-green-100 px-2 py-1 rounded-full">
-                              Utilisé
-                            </span>
-                          </>
-                        ) : (
-                          <>
-                            <XCircle className="text-orange-500 mr-1" size={16} />
-                            <span className="text-sm text-orange-800 bg-orange-100 px-2 py-1 rounded-full">
-                              En attente
-                            </span>
-                          </>
-                        )}
-                      </div>
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap">
-                      {getContractBadge(trainer.assigned_contract)}
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap">
-                      {getContractAcceptedStatus(trainer)}
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap">
+        <div className="grid gap-6 p-6">
+          {trainers.length === 0 ? (
+            <div className="text-center py-12 text-gray-500">
+              {filterDate ? 'Aucun formateur trouvé pour cet atelier' : 'Aucun formateur trouvé'}
+            </div>
+          ) : (
+            trainers.map((trainer) => (
+              <div
+                key={trainer.id}
+                className={`border border-gray-200 rounded-lg p-6 hover:shadow-md transition-shadow ${trainer.is_abandoned ? 'bg-red-50' : ''}`}
+              >
+                <div className="flex justify-between items-start mb-4">
+                  <div className="flex-1">
+                    <div className="flex items-center space-x-3 mb-2">
+                      <Users className="text-blue-600" size={20} />
+                      <h3 className="text-lg font-semibold text-gray-900">{trainer.trainer_code}</h3>
+                      {trainer.is_abandoned ? (
+                        <span className="text-sm text-red-800 bg-red-100 px-2 py-1 rounded-full">Abandonné</span>
+                      ) : trainer.is_claimed ? (
+                        <span className="text-sm text-green-800 bg-green-100 px-2 py-1 rounded-full">Utilisé</span>
+                      ) : (
+                        <span className="text-sm text-orange-800 bg-orange-100 px-2 py-1 rounded-full">En attente</span>
+                      )}
+                    </div>
+                    <p className="text-sm text-gray-600 mb-3">
+                      Atelier du {format(new Date(trainer.workshop_date), 'dd MMMM yyyy', { locale: fr })}
+                    </p>
+
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
+                      <div>{getContractBadge(trainer.assigned_contract)}</div>
+                      <div>{getContractAcceptedStatus(trainer)}</div>
+                    </div>
+
+                    <div className="flex items-center space-x-2 mt-3">
                       <button
                         onClick={() => handleToggleTrainerCodeSent(trainer.id, trainer.code_sent)}
                         className={`flex items-center space-x-2 px-3 py-1 rounded-lg text-sm font-medium transition-colors ${
@@ -504,15 +445,9 @@ const TrainersTab: React.FC<TrainersTabProps> = ({ initialFilterDate, allWorksho
                         }`}
                         title={trainer.code_sent ? 'Marquer comme non envoyé' : 'Marquer comme envoyé'}
                       >
-                        {trainer.code_sent ? (
-                          <MailCheck size={16} />
-                        ) : (
-                          <Mail size={16} />
-                        )}
+                        {trainer.code_sent ? <MailCheck size={16} /> : <Mail size={16} />}
                         <span>{trainer.code_sent ? 'Envoyé' : 'Non envoyé'}</span>
                       </button>
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap">
                       <button
                         onClick={() => handleToggleAbandonedStatus(trainer.id, trainer.is_abandoned)}
                         className={`flex items-center space-x-2 px-3 py-1 rounded-lg text-sm font-medium transition-colors ${
@@ -522,40 +457,37 @@ const TrainersTab: React.FC<TrainersTabProps> = ({ initialFilterDate, allWorksho
                         }`}
                         title={trainer.is_abandoned ? 'Marquer comme actif' : 'Marquer comme abandonné'}
                       >
-                        {trainer.is_abandoned ? (
-                          <UserX size={16} />
-                        ) : (
-                          <Users size={16} />
-                        )}
+                        {trainer.is_abandoned ? <UserX size={16} /> : <Users size={16} />}
                         <span>{trainer.is_abandoned ? 'Abandonné' : 'Actif'}</span>
                       </button>
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                      {trainer.created_at && format(new Date(trainer.created_at), 'dd/MM/yyyy HH:mm', { locale: fr })}
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
-                      <div className="flex space-x-2 justify-end">
-                        <button
-                          onClick={() => handleEdit(trainer)}
-                          className="p-2 text-blue-600 hover:bg-blue-50 rounded-lg transition-colors"
-                          title="Modifier le formateur"
-                        >
-                          <Edit2 size={18} />
-                        </button>
-                        <button
-                          onClick={() => handleDelete(trainer.id)}
-                          className="p-2 text-red-600 hover:bg-red-50 rounded-lg transition-colors"
-                          title="Supprimer le formateur"
-                        >
-                          <Trash2 size={18} />
-                        </button>
-                      </div>
-                    </td>
-                  </tr>
-                ))
-              )}
-            </tbody>
-          </table>
+                    </div>
+                  </div>
+                  <div className="flex space-x-2 ml-4">
+                    <button
+                      onClick={() => handleEdit(trainer)}
+                      className="p-2 text-blue-600 hover:bg-blue-50 rounded-lg transition-colors"
+                      title="Modifier le formateur"
+                    >
+                      <Edit2 size={18} />
+                    </button>
+                    <button
+                      onClick={() => handleDelete(trainer.id)}
+                      className="p-2 text-red-600 hover:bg-red-50 rounded-lg transition-colors"
+                      title="Supprimer le formateur"
+                    >
+                      <Trash2 size={18} />
+                    </button>
+                  </div>
+                </div>
+
+                {trainer.created_at && (
+                  <div className="mt-2 text-xs text-gray-500">
+                    Créé le {format(new Date(trainer.created_at), 'dd/MM/yyyy HH:mm', { locale: fr })}
+                  </div>
+                )}
+              </div>
+            ))
+          )}
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- switch trainers tab to card layout
- apply card-style layout for press articles tab
- update media highlights tab with cards

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68552c9e867083259a517b3109b75dbf