### PR TITLE
Group navigation tabs into categorized rows

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -7,43 +7,53 @@ interface NavigationProps {
 }
 
 const Navigation: React.FC<NavigationProps> = ({ activeTab, onTabChange }) => {
-  const tabs = [
-    { id: 'events', label: 'Événements', icon: Calendar },
-    { id: 'event-photos', label: 'Photos', icon: Image },
-    { id: 'workshops', label: 'Ateliers', icon: Settings },
-    { id: 'trainers', label: 'Formateurs', icon: Users },
-    { id: 'contracts', label: 'Contrats', icon: FileContract },
-    { id: 'registrations', label: 'Inscriptions', icon: UserCheck },
-    { id: 'guidelines', label: 'Directives', icon: FileText },
-    { id: 'initiatives', label: 'Initiatives', icon: Lightbulb },
-    { id: 'faqs', label: 'FAQs', icon: HelpCircle },
-    { id: 'testimonials', label: 'Témoignages', icon: MessageSquare },
-    { id: 'press-articles', label: 'Presse', icon: Newspaper },
-    { id: 'partners', label: 'Partenaires', icon: Handshake },
-    { id: 'media-highlights', label: 'Médias', icon: Newspaper },
+  const tabGroups = [
+    [
+      { id: 'events', label: 'Événements', icon: Calendar },
+      { id: 'event-photos', label: 'Photos', icon: Image },
+    ],
+    [
+      { id: 'workshops', label: 'Ateliers', icon: Settings },
+      { id: 'trainers', label: 'Formateurs', icon: Users },
+      { id: 'contracts', label: 'Contrats', icon: FileContract },
+      { id: 'registrations', label: 'Inscriptions', icon: UserCheck },
+      { id: 'guidelines', label: 'Directives', icon: FileText },
+    ],
+    [
+      { id: 'initiatives', label: 'Initiatives', icon: Lightbulb },
+      { id: 'faqs', label: 'FAQs', icon: HelpCircle },
+      { id: 'testimonials', label: 'Témoignages', icon: MessageSquare },
+      { id: 'press-articles', label: 'Presse', icon: Newspaper },
+      { id: 'partners', label: 'Partenaires', icon: Handshake },
+      { id: 'media-highlights', label: 'Médias', icon: Newspaper },
+    ],
   ];
 
   return (
     <nav className="bg-white shadow-sm border-b border-gray-200">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="flex space-x-8">
-          {tabs.map((tab) => {
-            const Icon = tab.icon;
-            return (
-              <button
-                key={tab.id}
-                onClick={() => onTabChange(tab.id)}
-                className={`flex items-center space-x-2 py-4 px-1 border-b-2 font-medium text-sm transition-colors ${
-                  activeTab === tab.id
-                    ? 'border-blue-500 text-blue-600'
-                    : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
-                }`}
-              >
-                <Icon size={20} />
-                <span>{tab.label}</span>
-              </button>
-            );
-          })}
+        <div className="space-y-2">
+          {tabGroups.map((group, index) => (
+            <div key={index} className="flex flex-wrap space-x-8">
+              {group.map((tab) => {
+                const Icon = tab.icon;
+                return (
+                  <button
+                    key={tab.id}
+                    onClick={() => onTabChange(tab.id)}
+                    className={`flex items-center space-x-2 py-4 px-1 border-b-2 font-medium text-sm transition-colors ${
+                      activeTab === tab.id
+                        ? 'border-blue-500 text-blue-600'
+                        : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+                    }`}
+                  >
+                    <Icon size={20} />
+                    <span>{tab.label}</span>
+                  </button>
+                );
+              })}
+            </div>
+          ))}
         </div>
       </div>
     </nav>


### PR DESCRIPTION
## Summary
- organize the navigation tabs by category so that each category occupies one line

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68552e61d3e0832595d7b96a80ee3870