### PR TITLE
Add payment tracking for workshops and trainers

### DIFF
--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -64,6 +64,7 @@ export interface TrainerRegistration {
   representative_name?: string;
   representative_function?: string;
   representative_email?: string;
+  is_paid?: boolean;
 }
 
 export interface WorkshopGuidelines {
@@ -102,6 +103,7 @@ export interface ClientContract {
   signature_code: string;
   is_signed: boolean;
   code_sent: boolean;
+  payment_received: boolean;
   signed_at?: string;
   created_at?: string;
 }
@@ -113,6 +115,8 @@ export interface WorkshopWithStatus extends WorkshopPassword {
     registered_trainers: number;
     all_claimed: boolean;
   };
+  unpaid_count?: number;
+  all_paid?: boolean;
 }
 
 export interface Testimonial {

--- a/supabase/migrations/20250620120000_payments_tracking.sql
+++ b/supabase/migrations/20250620120000_payments_tracking.sql
@@ -1,0 +1,19 @@
+/*
+  # Add payment tracking fields
+
+  1. Schema Changes
+    - Add `is_paid` boolean column to `trainer_registrations` table with default false
+    - Add `payment_received` boolean column to `client_contracts` table with default false
+*/
+
+-- Add is_paid flag to trainer_registrations table
+ALTER TABLE trainer_registrations
+ADD COLUMN IF NOT EXISTS is_paid boolean NOT NULL DEFAULT false;
+
+-- Add payment_received flag to client_contracts table
+ALTER TABLE client_contracts
+ADD COLUMN IF NOT EXISTS payment_received boolean NOT NULL DEFAULT false;
+
+-- Add comments for documentation
+COMMENT ON COLUMN trainer_registrations.is_paid IS 'Indique si la rémunération du formateur a été réglée';
+COMMENT ON COLUMN client_contracts.payment_received IS 'Indique si le paiement du client a été encaissé';


### PR DESCRIPTION
## Summary
- add migrations to track payments for trainers and client contracts
- extend data models with payment fields
- enable marking trainer registrations as paid
- show payment status and toggle encaissement for workshops

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_685d18eb8444832582736f3c755dba97