### PR TITLE
Fix all_paid calculation

### DIFF
--- a/src/components/WorkshopsTab.tsx
+++ b/src/components/WorkshopsTab.tsx
@@ -118,7 +118,7 @@ const WorkshopsTab: React.FC<WorkshopsTabProps> = ({ onNavigateWithFilter }) => 
               all_claimed
             },
             unpaid_count: unpaidCount,
-            all_paid
+            all_paid: allPaid
           };
         })
       );


### PR DESCRIPTION
## Summary
- use `allPaid` variable when setting the `all_paid` field in `WorkshopsTab`

## Testing
- `npm run lint` *(fails: 28 errors, 10 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_685d1d72797083258aeb4d855fc47ae4