### PR TITLE
Fix pending payment count and volunteer labels

### DIFF
--- a/src/components/WorkshopsTab.tsx
+++ b/src/components/WorkshopsTab.tsx
@@ -58,7 +58,7 @@ const WorkshopsTab: React.FC<WorkshopsTabProps> = ({ onNavigateWithFilter }) => 
           // Get registrations for this workshop
           const { data: registrationsData, error: registrationsError } = await supabase
             .from('trainer_registrations')
-            .select('trainer_code')
+            .select('id, trainer_code, is_paid')
             .eq('workshop_date', workshop.date);
 
           if (registrationsError) {


### PR DESCRIPTION
## Summary
- fix counting unpaid registrations in Workshops tab
- show 'Remboursé' wording for volunteer contracts
- confirm before toggling payment status

## Testing
- `npm run lint` *(fails: 28 errors, 10 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_685d26935f0483259145e20a12fb29d4