### PR TITLE
Add testimonials table migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
-journee-decouverte-backend
+# journee-decouverte-backend
+
+This project contains the migrations and frontend for managing workshop data with Supabase.
+
+## Migrations
+
+New migrations are located in `supabase/migrations`. Run them using the Supabase CLI:
+
+```bash
+supabase db reset
+```
+
+## Testimonials table
+
+The `testimonials` table is now created with row level security policies allowing public CRUD operations. This resolves 401 errors when retrieving testimonials via the REST API.

--- a/supabase/migrations/20250621120000_testimonials_table.sql
+++ b/supabase/migrations/20250621120000_testimonials_table.sql
@@ -1,0 +1,46 @@
+/*
+  # Create testimonials table and policies
+
+  1. Table
+    - testimonials
+      - id uuid primary key
+      - partner_name text not null
+      - quote text not null
+      - rating integer not null default 5
+      - "order" integer not null default 0
+      - logo_url text not null
+      - created_at timestamptz default now()
+
+  2. Security
+    - Enable RLS
+    - Add policies for public access (insert, select, update, delete)
+*/
+
+CREATE TABLE IF NOT EXISTS testimonials (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  partner_name text NOT NULL,
+  quote text NOT NULL,
+  rating integer NOT NULL DEFAULT 5 CHECK (rating >= 1 AND rating <= 5),
+  "order" integer NOT NULL DEFAULT 0,
+  logo_url text NOT NULL,
+  created_at timestamptz DEFAULT now()
+);
+
+ALTER TABLE testimonials ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Anyone can select testimonials" ON testimonials
+  FOR SELECT TO public
+  USING (true);
+
+CREATE POLICY "Anyone can insert testimonials" ON testimonials
+  FOR INSERT TO public
+  WITH CHECK (true);
+
+CREATE POLICY "Anyone can update testimonials" ON testimonials
+  FOR UPDATE TO public
+  USING (true)
+  WITH CHECK (true);
+
+CREATE POLICY "Anyone can delete testimonials" ON testimonials
+  FOR DELETE TO public
+  USING (true);


### PR DESCRIPTION
## Summary
- create `testimonials` table with RLS policies
- document migrations and the new table in README

## Testing
- `npm run lint` *(fails: 28 errors)*

------
https://chatgpt.com/codex/tasks/task_e_685d52903da08325876dcc0fd62dac66