### PR TITLE
Fix image URLs handling

### DIFF
--- a/src/components/EventPhotosTab.tsx
+++ b/src/components/EventPhotosTab.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Plus, Edit2, Trash2, Image as ImageIcon, Filter, X } from 'lucide-react';
 import { supabase } from '../lib/supabase';
+import { resolveImageUrl } from '../lib/image';
 import EventPhotoForm from './forms/EventPhotoForm';
 import type { EventPhoto, Event } from '../types/database';
 
@@ -70,10 +71,6 @@ const EventPhotosTab: React.FC<EventPhotosTabProps> = ({ initialFilterEventId, o
     return event ? event.occasion : 'Événement inconnu';
   };
 
-  const getPublicUrl = (path: string) => {
-    const { data } = supabase.storage.from(bucket).getPublicUrl(path);
-    return data.publicUrl;
-  };
 
   const handleFilterChange = (newId: string) => {
     const value = newId === '' ? null : newId;
@@ -175,7 +172,11 @@ const EventPhotosTab: React.FC<EventPhotosTabProps> = ({ initialFilterEventId, o
           ) : (
             photos.map(photo => (
               <div key={photo.id} className="border border-gray-200 rounded-lg p-6 hover:shadow-md transition-shadow flex items-center space-x-4">
-                <img src={getPublicUrl(photo.src)} alt={photo.alt} className="w-24 h-24 object-cover rounded" />
+                <img
+                  src={resolveImageUrl(photo.src, bucket, supabase)}
+                  alt={photo.alt}
+                  className="w-24 h-24 object-cover rounded"
+                />
                 <div className="flex-1">
                   <h3 className="text-lg font-medium text-gray-900">{getEventLabel(photo.event_id)}</h3>
                   <p className="text-sm text-gray-600">{photo.alt}</p>

--- a/src/components/InitiativesTab.tsx
+++ b/src/components/InitiativesTab.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Plus, Edit2, Trash2 } from 'lucide-react';
 import { supabase } from '../lib/supabase';
+import { resolveImageUrl } from '../lib/image';
 import InitiativeForm from './forms/InitiativeForm';
 import type { Initiative } from '../types/database';
 
@@ -58,10 +59,6 @@ const InitiativesTab: React.FC = () => {
     setEditingInitiative(null);
   };
 
-  const getPublicUrl = (path: string) => {
-    const { data } = supabase.storage.from(bucket).getPublicUrl(path);
-    return data.publicUrl;
-  };
 
   if (loading) {
     return (
@@ -99,7 +96,11 @@ const InitiativesTab: React.FC = () => {
               >
                 <div className="flex space-x-4">
                   {initiative.logo_url && (
-                    <img src={getPublicUrl(initiative.logo_url)} alt={initiative.title} className="h-16 w-16 object-contain" />
+                    <img
+                      src={resolveImageUrl(initiative.logo_url, bucket, supabase)}
+                      alt={initiative.title}
+                      className="h-16 w-16 object-contain"
+                    />
                   )}
                   <div>
                     <h3 className="text-lg font-semibold text-gray-900">{initiative.title}</h3>

--- a/src/components/MediaHighlightsTab.tsx
+++ b/src/components/MediaHighlightsTab.tsx
@@ -3,6 +3,7 @@ import { Plus, Edit2, Trash2 } from 'lucide-react';
 import { format } from 'date-fns';
 import { fr } from 'date-fns/locale';
 import { supabase } from '../lib/supabase';
+import { resolveImageUrl } from '../lib/image';
 import MediaHighlightForm from './forms/MediaHighlightForm';
 import type { MediaHighlight } from '../types/database';
 
@@ -83,14 +84,22 @@ const MediaHighlightsTab: React.FC = () => {
                 <div className="flex justify-between items-start mb-4">
                   <div className="flex-1">
                     <div className="flex items-center space-x-3 mb-2">
-                      <img src={h.media_logo} alt={h.media_name} className="h-8 w-8 object-contain" />
+                      <img
+                        src={resolveImageUrl(h.media_logo, 'media-highlights', supabase)}
+                        alt={h.media_name}
+                        className="h-8 w-8 object-contain"
+                      />
                       <h3 className="text-lg font-semibold text-gray-900">{h.title}</h3>
                     </div>
                     <p className="text-sm text-gray-600">
                       {h.media_name} - {format(new Date(h.date), 'dd/MM/yyyy', { locale: fr })}
                     </p>
                     <div className="mt-2">
-                      <img src={h.image_url} alt={h.title} className="h-32 w-full object-cover rounded" />
+                      <img
+                        src={resolveImageUrl(h.image_url, 'media-highlights', supabase)}
+                        alt={h.title}
+                        className="h-32 w-full object-cover rounded"
+                      />
                     </div>
                   </div>
                   <div className="flex space-x-2 ml-4">

--- a/src/components/PartnersTab.tsx
+++ b/src/components/PartnersTab.tsx
@@ -3,6 +3,7 @@ import { Plus, Edit2, Trash2 } from 'lucide-react';
 import { format } from 'date-fns';
 import { fr } from 'date-fns/locale';
 import { supabase } from '../lib/supabase';
+import { resolveImageUrl } from '../lib/image';
 import PartnerForm from './forms/PartnerForm';
 import type { Partner } from '../types/database';
 
@@ -57,10 +58,6 @@ const PartnersTab: React.FC = () => {
     setEditingPartner(null);
   };
 
-  const getPublicUrl = (path: string) => {
-    const { data } = supabase.storage.from(bucket).getPublicUrl(path);
-    return data.publicUrl;
-  };
 
   if (loading) {
     return (
@@ -97,7 +94,11 @@ const PartnersTab: React.FC = () => {
                   <div className="flex-1">
                     <div className="flex items-center space-x-3 mb-2">
                       {p.logo_url && (
-                        <img src={getPublicUrl(p.logo_url)} alt={p.name} className="h-8 w-8 object-contain" />
+                        <img
+                          src={resolveImageUrl(p.logo_url, bucket, supabase)}
+                          alt={p.name}
+                          className="h-8 w-8 object-contain"
+                        />
                       )}
                       <h3 className="text-lg font-semibold text-gray-900">{p.name}</h3>
                     </div>

--- a/src/components/PressArticlesTab.tsx
+++ b/src/components/PressArticlesTab.tsx
@@ -3,6 +3,7 @@ import { Plus, Edit2, Trash2 } from 'lucide-react';
 import { format } from 'date-fns';
 import { fr } from 'date-fns/locale';
 import { supabase } from '../lib/supabase';
+import { resolveImageUrl } from '../lib/image';
 import PressArticleForm from './forms/PressArticleForm';
 import type { PressArticle } from '../types/database';
 
@@ -56,10 +57,6 @@ const PressArticlesTab: React.FC = () => {
     setEditingArticle(null);
   };
 
-  const getPublicUrl = (path: string) => {
-    const { data } = supabase.storage.from(bucket).getPublicUrl(path);
-    return data.publicUrl;
-  };
 
   if (loading) {
     return (
@@ -93,7 +90,11 @@ const PressArticlesTab: React.FC = () => {
                   <div className="flex-1">
                     <div className="flex items-center space-x-3 mb-2">
                       {a.logo_url && (
-                        <img src={getPublicUrl(a.logo_url)} alt={a.publication} className="h-8 w-8 object-contain" />
+                        <img
+                          src={resolveImageUrl(a.logo_url, bucket, supabase)}
+                          alt={a.publication}
+                          className="h-8 w-8 object-contain"
+                        />
                       )}
                       <h3 className="text-lg font-semibold text-gray-900">{a.title}</h3>
                     </div>

--- a/src/components/TestimonialsTab.tsx
+++ b/src/components/TestimonialsTab.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Plus, Edit2, Trash2 } from 'lucide-react';
 import { supabase } from '../lib/supabase';
+import { resolveImageUrl } from '../lib/image';
 import TestimonialForm from './forms/TestimonialForm';
 import type { Testimonial } from '../types/database';
 
@@ -81,14 +82,14 @@ const TestimonialsTab: React.FC = () => {
             <div className="text-center py-12 text-gray-500">Aucun témoignage trouvé</div>
           ) : (
             testimonials.map((t) => {
-              const { data } = supabase.storage.from('testimonials').getPublicUrl(t.logo_url);
+              const logoUrl = resolveImageUrl(t.logo_url, 'testimonials', supabase);
               return (
                 <div
                   key={t.id}
                   className="border border-gray-200 rounded-lg p-6 flex justify-between items-start hover:shadow-md transition-shadow"
                 >
                   <div className="flex space-x-4">
-                    <img src={data.publicUrl} alt={t.partner_name} className="h-16 w-16 object-contain" />
+                    <img src={logoUrl} alt={t.partner_name} className="h-16 w-16 object-contain" />
                     <div>
                       <h3 className="text-lg font-semibold text-gray-900">{t.partner_name}</h3>
                       <p className="text-gray-700 mb-1">{t.quote}</p>

--- a/src/components/forms/InitiativeForm.tsx
+++ b/src/components/forms/InitiativeForm.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { X, Save, Plus, Trash2 } from 'lucide-react';
 import { supabase } from '../../lib/supabase';
+import { resolveImageUrl } from '../../lib/image';
 import type { Initiative, InitiativeSocialLink } from '../../types/database';
 
 interface InitiativeFormProps {
@@ -45,12 +46,10 @@ const InitiativeForm: React.FC<InitiativeFormProps> = ({ initiative, onClose, on
         logo_url: initiative.logo_url
       });
       if (initiative.image_url) {
-        const { data } = supabase.storage.from(bucket).getPublicUrl(initiative.image_url);
-        setImagePreview(data.publicUrl);
+        setImagePreview(resolveImageUrl(initiative.image_url, bucket, supabase));
       }
       if (initiative.logo_url) {
-        const { data } = supabase.storage.from(bucket).getPublicUrl(initiative.logo_url);
-        setLogoPreview(data.publicUrl);
+        setLogoPreview(resolveImageUrl(initiative.logo_url, bucket, supabase));
       }
     }
   }, [initiative]);

--- a/src/components/forms/MediaHighlightForm.tsx
+++ b/src/components/forms/MediaHighlightForm.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { X, Save, ExternalLink } from 'lucide-react';
 import { supabase } from '../../lib/supabase';
+import { resolveImageUrl } from '../../lib/image';
 import type { MediaHighlight } from '../../types/database';
 
 interface MediaHighlightFormProps {
@@ -39,8 +40,10 @@ const MediaHighlightForm: React.FC<MediaHighlightFormProps> = ({ highlight, onCl
         media_logo: highlight.media_logo,
         image_url: highlight.image_url
       });
-      if (highlight.media_logo) setLogoPreview(highlight.media_logo);
-      if (highlight.image_url) setImagePreview(highlight.image_url);
+      if (highlight.media_logo)
+        setLogoPreview(resolveImageUrl(highlight.media_logo, bucket, supabase));
+      if (highlight.image_url)
+        setImagePreview(resolveImageUrl(highlight.image_url, bucket, supabase));
     }
   }, [highlight]);
 

--- a/src/components/forms/PartnerForm.tsx
+++ b/src/components/forms/PartnerForm.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { X, Save, Plus, Trash2, ExternalLink } from 'lucide-react';
 import { supabase } from '../../lib/supabase';
+import { resolveImageUrl } from '../../lib/image';
 import type { Partner } from '../../types/database';
 
 interface PartnerFormProps {
@@ -43,8 +44,7 @@ const PartnerForm: React.FC<PartnerFormProps> = ({ partner, onClose, onSave }) =
         collaboration_status: partner.collaboration_status || ''
       });
       if (partner.logo_url) {
-        const { data } = supabase.storage.from(bucket).getPublicUrl(partner.logo_url);
-        setLogoPreview(data.publicUrl);
+        setLogoPreview(resolveImageUrl(partner.logo_url, bucket, supabase));
       }
     }
   }, [partner]);

--- a/src/components/forms/PressArticleForm.tsx
+++ b/src/components/forms/PressArticleForm.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { X, Save, ExternalLink } from 'lucide-react';
 import { supabase } from '../../lib/supabase';
+import { resolveImageUrl } from '../../lib/image';
 import type { PressArticle } from '../../types/database';
 
 interface PressArticleFormProps {
@@ -36,8 +37,7 @@ const PressArticleForm: React.FC<PressArticleFormProps> = ({ article, onClose, o
         featured: article.featured,
       });
       if (article.logo_url) {
-        const { data } = supabase.storage.from(bucket).getPublicUrl(article.logo_url);
-        setLogoPreview(data.publicUrl);
+        setLogoPreview(resolveImageUrl(article.logo_url, bucket, supabase));
       }
     }
   }, [article]);

--- a/src/components/forms/TestimonialForm.tsx
+++ b/src/components/forms/TestimonialForm.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { X, Save } from 'lucide-react';
 import { supabase } from '../../lib/supabase';
+import { resolveImageUrl } from '../../lib/image';
 import type { Testimonial } from '../../types/database';
 
 interface TestimonialFormProps {
@@ -32,8 +33,7 @@ const TestimonialForm: React.FC<TestimonialFormProps> = ({ testimonial, onClose,
         logo_url: testimonial.logo_url
       });
       if (testimonial.logo_url) {
-        const { data } = supabase.storage.from('testimonials').getPublicUrl(testimonial.logo_url);
-        setPreviewUrl(data.publicUrl);
+        setPreviewUrl(resolveImageUrl(testimonial.logo_url, 'testimonials', supabase));
       }
     }
   }, [testimonial]);

--- a/src/lib/image.ts
+++ b/src/lib/image.ts
@@ -1,0 +1,11 @@
+export const resolveImageUrl = (path: string, bucket: string, supabase: any): string => {
+  if (!path) return '';
+  if (path.startsWith('http://') || path.startsWith('https://')) {
+    return path;
+  }
+  if (path.startsWith('/images/') || path.startsWith('images/')) {
+    return path.startsWith('/') ? path : `/${path}`;
+  }
+  const { data } = supabase.storage.from(bucket).getPublicUrl(path);
+  return data.publicUrl;
+};


### PR DESCRIPTION
## Summary
- add `resolveImageUrl` helper to centralize image URL resolution
- display images from local files, remote URLs or Supabase storage
- use `resolveImageUrl` across forms and tabs for testimonials, initiatives, partners, press articles, media highlights and event photos

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npm run build`
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685d5bc917b483258f4ba51ef0b5027d